### PR TITLE
Make anonymous memory maps private by default on unix

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -112,7 +112,7 @@ impl MmapInner {
         MmapInner::new(
             len,
             libc::PROT_READ | libc::PROT_WRITE,
-            libc::MAP_SHARED | libc::MAP_ANON | stack,
+            libc::MAP_PRIVATE | libc::MAP_ANON | stack,
             -1,
             0,
         )


### PR DESCRIPTION
Currently map_anon will call mmap with MAP_SHARED | MAP_ANON.

This prevents debuggers from easily working with executable code inside these mmaps as MAP_SHARED implies any changes made to the mmap will be flushed to a file or to other processes. However, it is not actually necessary to call it with MAP_SHARED. There is no documentation implying the resulting memory map is MAP_SHARED, and the only observable behaviour (the mapping being shared with child processes) would cause other UB anyway (allows you to change the content of a &[u8] from a child process) so it shouldn't be relied on to begin with. Therefore making anonymous memorymaps MAP_PRIVATE seems fine.