### PR TITLE
Run Rustfmt and Clippy via main CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,27 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        profile: minimal
+        target: x86_64-pc-windows-gnu
+
+    - name: Run checks
+      env:
+        CLIPPY_OPTS: --allow clippy::len_without_is_empty --allow clippy::missing_safety_doc
+      run: |
+        cargo fmt -- --check
+        cargo clippy -- $CLIPPY_OPTS
+        cargo clippy --target x86_64-pc-windows-gnu -- $CLIPPY_OPTS
+
   test-win:
     runs-on: windows-2019
     strategy:
@@ -23,6 +44,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        profile: minimal
         target: ${{ matrix.target }}
         override: true
 
@@ -55,6 +77,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: stable
+        profile: minimal
         target: ${{ matrix.target }}
         override: true
 
@@ -71,6 +94,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         toolchain: 1.32.0
+        profile: minimal
         override: true
 
     - name: Run tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,11 +21,11 @@ jobs:
 
     - name: Run checks
       env:
-        CLIPPY_OPTS: --allow clippy::len_without_is_empty --allow clippy::missing_safety_doc
+        CLIPPY_OPTS: --all-targets -- --allow clippy::len_without_is_empty --allow clippy::missing_safety_doc
       run: |
         cargo fmt -- --check
-        cargo clippy -- $CLIPPY_OPTS
-        cargo clippy --target x86_64-pc-windows-gnu -- $CLIPPY_OPTS
+        cargo clippy $CLIPPY_OPTS
+        cargo clippy --target x86_64-pc-windows-gnu $CLIPPY_OPTS
 
   test-win:
     runs-on: windows-2019

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -946,6 +946,7 @@ mod test {
                 .unwrap()
         };
         (&mut mmap[..]).write_all(write).unwrap();
+        mmap.flush_async_range(0, write.len()).unwrap();
         mmap.flush_range(0, write.len()).unwrap();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use windows::MmapInner;
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-use crate::unix::MmapInner;
+use unix::MmapInner;
 
 use std::fmt;
 use std::fs::File;
@@ -537,7 +537,9 @@ impl MmapRaw {
     /// To safely dereference this pointer, you need to make sure that the file has not been
     /// truncated since the memory map was created.
     #[inline]
-    pub fn as_ptr(&self) -> *const u8 { self.inner.ptr() }
+    pub fn as_ptr(&self) -> *const u8 {
+        self.inner.ptr()
+    }
 
     /// Returns an unsafe mutable pointer to the memory mapped file.
     ///
@@ -546,13 +548,17 @@ impl MmapRaw {
     /// To safely dereference this pointer, you need to make sure that the file has not been
     /// truncated since the memory map was created.
     #[inline]
-    pub fn as_mut_ptr(&self) -> *mut u8 { self.inner.ptr() as _ }
+    pub fn as_mut_ptr(&self) -> *mut u8 {
+        self.inner.ptr() as _
+    }
 
     /// Returns the length in bytes of the memory map.
     ///
     /// Note that truncating the file can cause the length to change (and render this value unusable).
     #[inline]
-    pub fn len(&self) -> usize { self.inner.len() }
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
 }
 
 impl fmt::Debug for MmapRaw {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl MmapOptions {
     /// ```
     pub unsafe fn map(&self, file: &File) -> Result<Mmap> {
         MmapInner::map(self.get_len(file)?, file, self.offset, self.populate)
-            .map(|inner| Mmap { inner: inner })
+            .map(|inner| Mmap { inner })
     }
 
     /// Creates a readable and executable memory map backed by a file.
@@ -233,7 +233,7 @@ impl MmapOptions {
     /// variety of reasons, such as when the file is not open with read permissions.
     pub unsafe fn map_exec(&self, file: &File) -> Result<Mmap> {
         MmapInner::map_exec(self.get_len(file)?, file, self.offset, self.populate)
-            .map(|inner| Mmap { inner: inner })
+            .map(|inner| Mmap { inner })
     }
 
     /// Creates a writeable memory map backed by a file.
@@ -271,7 +271,7 @@ impl MmapOptions {
     /// ```
     pub unsafe fn map_mut(&self, file: &File) -> Result<MmapMut> {
         MmapInner::map_mut(self.get_len(file)?, file, self.offset, self.populate)
-            .map(|inner| MmapMut { inner: inner })
+            .map(|inner| MmapMut { inner })
     }
 
     /// Creates a copy-on-write memory map backed by a file.
@@ -300,7 +300,7 @@ impl MmapOptions {
     /// ```
     pub unsafe fn map_copy(&self, file: &File) -> Result<MmapMut> {
         MmapInner::map_copy(self.get_len(file)?, file, self.offset, self.populate)
-            .map(|inner| MmapMut { inner: inner })
+            .map(|inner| MmapMut { inner })
     }
 
     /// Creates a copy-on-write read-only memory map backed by a file.
@@ -333,7 +333,7 @@ impl MmapOptions {
     /// ```
     pub unsafe fn map_copy_read_only(&self, file: &File) -> Result<Mmap> {
         MmapInner::map_copy_read_only(self.get_len(file)?, file, self.offset, self.populate)
-            .map(|inner| Mmap { inner: inner })
+            .map(|inner| Mmap { inner })
     }
 
     /// Creates an anonymous memory map.
@@ -345,7 +345,7 @@ impl MmapOptions {
     ///
     /// This method returns an error when the underlying system call fails.
     pub fn map_anon(&self) -> Result<MmapMut> {
-        MmapInner::map_anon(self.len.unwrap_or(0), self.stack).map(|inner| MmapMut { inner: inner })
+        MmapInner::map_anon(self.len.unwrap_or(0), self.stack).map(|inner| MmapMut { inner })
     }
 
     /// Creates a raw memory map.
@@ -356,7 +356,7 @@ impl MmapOptions {
     /// variety of reasons, such as when the file is not open with read and write permissions.
     pub fn map_raw(&self, file: &File) -> Result<MmapRaw> {
         MmapInner::map_mut(self.get_len(file)?, file, self.offset, self.populate)
-            .map(|inner| MmapRaw { inner: inner })
+            .map(|inner| MmapRaw { inner })
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -66,7 +66,7 @@ impl MmapInner {
             } else {
                 Ok(MmapInner {
                     ptr: ptr.offset(alignment as isize),
-                    len: len,
+                    len,
                 })
             }
         }
@@ -163,7 +163,7 @@ impl MmapInner {
         let aligned_len = len + alignment;
         let result = unsafe {
             libc::msync(
-                self.ptr.offset(aligned_offset as isize),
+                self.ptr.add(aligned_offset),
                 aligned_len as libc::size_t,
                 libc::MS_ASYNC,
             )

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -31,8 +31,12 @@ const SECTION_MAP_READ: DWORD = 0x0004;
 const SECTION_MAP_EXECUTE: DWORD = 0x0008;
 const SECTION_EXTEND_SIZE: DWORD = 0x0010;
 const SECTION_MAP_EXECUTE_EXPLICIT: DWORD = 0x0020;
-const SECTION_ALL_ACCESS: DWORD = STANDARD_RIGHTS_REQUIRED | SECTION_QUERY
-    | SECTION_MAP_WRITE | SECTION_MAP_READ | SECTION_MAP_EXECUTE | SECTION_EXTEND_SIZE;
+const SECTION_ALL_ACCESS: DWORD = STANDARD_RIGHTS_REQUIRED
+    | SECTION_QUERY
+    | SECTION_MAP_WRITE
+    | SECTION_MAP_READ
+    | SECTION_MAP_EXECUTE
+    | SECTION_EXTEND_SIZE;
 
 const PAGE_READONLY: DWORD = 0x02;
 const PAGE_READWRITE: DWORD = 0x04;
@@ -82,9 +86,7 @@ struct SYSTEM_INFO {
 }
 
 extern "system" {
-    fn CloseHandle(
-        hObject: HANDLE,
-    ) -> BOOL;
+    fn CloseHandle(hObject: HANDLE) -> BOOL;
 
     fn CreateFileMappingW(
         hFile: HANDLE,
@@ -95,14 +97,9 @@ extern "system" {
         lpName: LPCWSTR,
     ) -> HANDLE;
 
-    fn FlushViewOfFile(
-        lpBaseAddress: LPCVOID,
-        dwNumberOfBytesToFlush: SIZE_T,
-    ) -> BOOL;
+    fn FlushViewOfFile(lpBaseAddress: LPCVOID, dwNumberOfBytesToFlush: SIZE_T) -> BOOL;
 
-    fn UnmapViewOfFile(
-        lpBaseAddress: LPCVOID,
-    ) -> BOOL;
+    fn UnmapViewOfFile(lpBaseAddress: LPCVOID) -> BOOL;
 
     fn MapViewOfFile(
         hFileMappingObject: HANDLE,
@@ -119,9 +116,7 @@ extern "system" {
         lpflOldProtect: PDWORD,
     ) -> BOOL;
 
-    fn GetSystemInfo(
-        lpSystemInfo: LPSYSTEM_INFO,
-    );
+    fn GetSystemInfo(lpSystemInfo: LPSYSTEM_INFO);
 }
 
 pub struct MmapInner {


### PR DESCRIPTION
I only targeted the simple code style lints and excluded things like missing safety docs from the CI as writing those docs will take a bit more effort. But this would ensure that we do not regress w.r.t. Rustfmt or Clippy. I also did the test code in a separate commit so that it is to drop from the PR if you think the cost-benefit trade-off for the test code is not worth it.