### PR TITLE
API Rework to support RawFd on Unix platforms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,14 @@
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
+use crate::windows::file_len;
+#[cfg(windows)]
 use crate::windows::MmapInner;
 
 #[cfg(unix)]
 mod unix;
+#[cfg(unix)]
+use crate::unix::file_len;
 #[cfg(unix)]
 use crate::unix::MmapInner;
 
@@ -137,7 +141,8 @@ impl MmapOptions {
     /// Returns the configured length, or the length of the provided file.
     fn get_len(&self, file: &File) -> Result<usize> {
         self.len.map(Ok).unwrap_or_else(|| {
-            let len = file.metadata()?.len() - self.offset;
+            let file_len = file_len(file)?;
+            let len = file_len as u64 - self.offset;
             if len > (usize::MAX as u64) {
                 return Err(Error::new(
                     ErrorKind::InvalidData,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-use windows::MmapInner;
+use crate::windows::MmapInner;
 
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-use unix::MmapInner;
+use crate::unix::MmapInner;
 
 #[cfg(not(any(unix, windows)))]
 mod stub;

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -235,5 +235,14 @@ fn page_size() -> usize {
 }
 
 pub fn file_len(file: &File) -> io::Result<usize> {
-    Ok(file.metadata()?.len() as usize)
+    unsafe {
+        let mut stat: libc::stat = std::mem::zeroed();
+
+        let result = libc::fstat(file.as_raw_fd(), &mut stat);
+        if result == 0 {
+            Ok(stat.st_size as usize)
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
 }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -233,3 +233,7 @@ unsafe impl Send for MmapInner {}
 fn page_size() -> usize {
     unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
 }
+
+pub fn file_len(file: &File) -> io::Result<usize> {
+    Ok(file.metadata()?.len() as usize)
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,7 +1,6 @@
 extern crate libc;
 
-use std::fs::File;
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::RawFd;
 use std::{io, ptr};
 
 #[cfg(any(
@@ -72,53 +71,53 @@ impl MmapInner {
         }
     }
 
-    pub fn map(len: usize, file: &File, offset: u64, populate: bool) -> io::Result<MmapInner> {
+    pub fn map(len: usize, file: RawFd, offset: u64, populate: bool) -> io::Result<MmapInner> {
         let populate = if populate { MAP_POPULATE } else { 0 };
         MmapInner::new(
             len,
             libc::PROT_READ,
             libc::MAP_SHARED | populate,
-            file.as_raw_fd(),
+            file,
             offset,
         )
     }
 
-    pub fn map_exec(len: usize, file: &File, offset: u64, populate: bool) -> io::Result<MmapInner> {
+    pub fn map_exec(len: usize, file: RawFd, offset: u64, populate: bool) -> io::Result<MmapInner> {
         let populate = if populate { MAP_POPULATE } else { 0 };
         MmapInner::new(
             len,
             libc::PROT_READ | libc::PROT_EXEC,
             libc::MAP_SHARED | populate,
-            file.as_raw_fd(),
+            file,
             offset,
         )
     }
 
-    pub fn map_mut(len: usize, file: &File, offset: u64, populate: bool) -> io::Result<MmapInner> {
+    pub fn map_mut(len: usize, file: RawFd, offset: u64, populate: bool) -> io::Result<MmapInner> {
         let populate = if populate { MAP_POPULATE } else { 0 };
         MmapInner::new(
             len,
             libc::PROT_READ | libc::PROT_WRITE,
             libc::MAP_SHARED | populate,
-            file.as_raw_fd(),
+            file,
             offset,
         )
     }
 
-    pub fn map_copy(len: usize, file: &File, offset: u64, populate: bool) -> io::Result<MmapInner> {
+    pub fn map_copy(len: usize, file: RawFd, offset: u64, populate: bool) -> io::Result<MmapInner> {
         let populate = if populate { MAP_POPULATE } else { 0 };
         MmapInner::new(
             len,
             libc::PROT_READ | libc::PROT_WRITE,
             libc::MAP_PRIVATE | populate,
-            file.as_raw_fd(),
+            file,
             offset,
         )
     }
 
     pub fn map_copy_read_only(
         len: usize,
-        file: &File,
+        file: RawFd,
         offset: u64,
         populate: bool,
     ) -> io::Result<MmapInner> {
@@ -127,7 +126,7 @@ impl MmapInner {
             len,
             libc::PROT_READ,
             libc::MAP_PRIVATE | populate,
-            file.as_raw_fd(),
+            file,
             offset,
         )
     }
@@ -234,11 +233,11 @@ fn page_size() -> usize {
     unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
 }
 
-pub fn file_len(file: &File) -> io::Result<usize> {
+pub fn file_len(file: RawFd) -> io::Result<usize> {
     unsafe {
         let mut stat: libc::stat = std::mem::zeroed();
 
-        let result = libc::fstat(file.as_raw_fd(), &mut stat);
+        let result = libc::fstat(file, &mut stat);
         if result == 0 {
             Ok(stat.st_size as usize)
         } else {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -434,3 +434,7 @@ fn allocation_granularity() -> usize {
         info.dwAllocationGranularity as usize
     }
 }
+
+pub fn file_len(file: &File) -> io::Result<usize> {
+    Ok(file.metadata()?.len() as usize)
+}


### PR DESCRIPTION
Hi,

Here's an implementation of the solution you suggested yesterday to support RawFd on Unix platforms.

One thing that deviates is that you suggested to use the Into trait, but I'm not sure that consuming the argument is what we'd want?

This has been tested on Linux, with the unit tests passing and a real-world program using a RawFd without a backing file descriptor. I don't have a windows box, so it's only compile-tested there.

Fixes #18 