### PR TITLE
Implement the StableDeref trait

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
       run: rustup default stable-${{ matrix.target }}
 
     - name: Run tests
-      run: cargo test
+      run: cargo test --all-features
 
   test-macos-catalina:
     runs-on: macos-10.15
@@ -53,7 +53,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Run tests
-      run: cargo test
+      run: cargo test --all-features
 
   test-linux:
     runs-on: ubuntu-20.04
@@ -74,7 +74,7 @@ jobs:
       run: sudo apt install gcc-multilib
 
     - name: Run tests
-      run: cargo test
+      run: cargo test --all-features
 
   check-stub:
     runs-on: ubuntu-20.04
@@ -91,7 +91,7 @@ jobs:
         override: true
 
     - name: Run check
-      run: cargo check --target wasm32-unknown-unknown
+      run: cargo check --all-features --target wasm32-unknown-unknown
 
   test-msrv:
     runs-on: ubuntu-20.04
@@ -102,9 +102,9 @@ jobs:
     - name: Install toolchain
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.32.0
+        toolchain: 1.36.0
         profile: minimal
         override: true
 
     - name: Run tests
-      run: cargo test
+      run: cargo test --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ description = "Cross-platform Rust API for memory-mapped file IO"
 keywords = ["mmap", "memory-map", "io", "file"]
 edition = "2018"
 
+[dependencies]
+stable_deref_trait = { version = "1.0", optional = true }
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
 tempdir = "0.3"
+owning_ref = "0.4.1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Build Status](https://github.com/RazrFalcon/memmap2-rs/workflows/Rust/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/memmap2.svg)](https://crates.io/crates/memmap2)
 [![Documentation](https://docs.rs/memmap2/badge.svg)](https://docs.rs/memmap2)
-[![Rust 1.31+](https://img.shields.io/badge/rust-1.31+-orange.svg)](https://www.rust-lang.org)
+[![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-orange.svg)](https://www.rust-lang.org)
 
 A Rust library for cross-platform memory mapped IO.
 


### PR DESCRIPTION
See https://crates.io/crates/stable_deref_trait

This marker trait can be used by abstractions similar to `owning_ref` in order to have a complex struct that borrows byte slices from a `Mmap` and store it next to that `Mmap` to eliminate the lifetime parameter.