### PR TITLE
Support zero-size `Mmap` and `MmapMut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -981,7 +981,7 @@ mod test {
         assert_eq!(&incr[..], &mmap[..]);
     }
 
-    /// Checks that a 0-length file will not be mapped.
+    /// Checks that "mapping" a 0-length file derefs to an empty slice.
     #[test]
     fn map_empty_file() {
         let tempdir = tempdir::TempDir::new("mmap").unwrap();
@@ -993,8 +993,10 @@ mod test {
             .create(true)
             .open(&path)
             .unwrap();
-        let mmap = unsafe { Mmap::map(&file) };
-        assert!(mmap.is_err());
+        let mmap = unsafe { Mmap::map(&file).unwrap() };
+        assert!(mmap.is_empty());
+        let mmap = unsafe { MmapMut::map_mut(&file).unwrap() };
+        assert!(mmap.is_empty());
     }
 
     #[test]
@@ -1019,7 +1021,7 @@ mod test {
 
     #[test]
     fn map_anon_zero_len() {
-        assert!(MmapOptions::new().map_anon().is_err())
+        assert!(MmapOptions::new().map_anon().unwrap().is_empty())
     }
 
     #[test]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -42,8 +42,38 @@ impl MmapInner {
         let alignment = offset % page_size() as u64;
         let aligned_offset = offset - alignment;
         let aligned_len = len + alignment as usize;
-        // Ensure a non-zero length for the underlying mapping
+
+        // `libc::mmap` does not support zero-size mappings. POSIX defines:
+        //
+        // https://pubs.opengroup.org/onlinepubs/9699919799/functions/mmap.html
+        // > If `len` is zero, `mmap()` shall fail and no mapping shall be established.
+        //
+        // So if we would create such a mapping, crate a one-byte mapping instead:
         let aligned_len = aligned_len.max(1);
+
+        // Note that in that case `MmapInner::len` is still set to zero,
+        // and `Mmap` will still dereferences to an empty slice.
+        //
+        // If this mapping is backed by an empty file, we create a mapping larger than the file.
+        // This is unusual but well-defined. On the same man page, POSIX further defines:
+        //
+        // > The `mmap()` function can be used to map a region of memory that is larger
+        // > than the current size of the object.
+        //
+        // (The object here is the file.)
+        //
+        // > Memory access within the mapping but beyond the current end of the underlying
+        // > objects may result in SIGBUS signals being sent to the process. The reason for this
+        // > is that the size of the object can be manipulated by other processes and can change
+        // > at any moment. The implementation should tell the application that a memory reference
+        // > is outside the object where this can be detected; otherwise, written data may be lost
+        // > and read data may not reflect actual data in the object.
+        //
+        // Because `MmapInner::len` is not incremented, this increment of `aligned_len`
+        // will not allow accesses past the end of the file and will not cause SIGBUS.
+        //
+        // (SIGBUS is still possible by mapping a non-empty file and then truncating it
+        // to a shorter size, but that is unrelated to this handling of empty files.)
 
         unsafe {
             let ptr = libc::mmap(


### PR DESCRIPTION
Fixes https://github.com/danburkert/memmap-rs/issues/72
Fixes https://github.com/RazrFalcon/memmap2-rs/issues/23

Previously, mapping an empty file or requesting a zero-size mapping would return an error because underlying OS APIs do not support zero-size mappings. Now, this crate instead requests a one-byte mapping (which most lilkely ends up rounded up to one memory page) but still has `Deref` return an empty slice in those cases.

This is the behavior suggested for Unix in https://github.com/danburkert/memmap-rs/issues/72#issuecomment-428872242

On Windows, docs for `CreateFileMappingW` say:
https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw
> `dwMaximumSizeHigh`
>
> The high-order DWORD of the maximum size of the file mapping object.
>
> `dwMaximumSizeLow`
>
> The low-order DWORD of the maximum size of the file mapping object.
>
> If this parameter and dwMaximumSizeHigh are 0 (zero), the maximum size of the file mapping object is equal to the current size of the file that hFile identifies.
>
> An attempt to map a file with a length of 0 (zero) fails with an error code of ERROR_FILE_INVALID. Applications should test for files with a length of 0 (zero) and reject those files.

~~Hopefully that last paragraph only applies when `dwMaximumSize` is zero (which this PR avoids), but that is not clear to me.~~

Edit: nope: https://github.com/RazrFalcon/memmap2-rs/pull/25#issuecomment-920779236