### PR TITLE
Extend MmapAsRawDesc to handle anything implementing AsRawFd

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use crate::stub::file_len;
 use crate::stub::MmapInner;
 
 use std::fmt;
+#[cfg(not(unix))]
 use std::fs::File;
 use std::io::{Error, ErrorKind, Result};
 use std::ops::{Deref, DerefMut};
@@ -48,16 +49,19 @@ impl MmapAsRawDesc for &File {
 }
 
 #[cfg(unix)]
-impl MmapAsRawDesc for &File {
+impl MmapAsRawDesc for RawFd {
     fn as_raw_desc(&self) -> MmapRawDescriptor {
-        MmapRawDescriptor(self.as_raw_fd())
+        MmapRawDescriptor(*self)
     }
 }
 
 #[cfg(unix)]
-impl MmapAsRawDesc for RawFd {
+impl<'a, T> MmapAsRawDesc for &'a T
+where
+    T: AsRawFd,
+{
     fn as_raw_desc(&self) -> MmapRawDescriptor {
-        MmapRawDescriptor(*self)
+        MmapRawDescriptor(self.as_raw_fd())
     }
 }
 


### PR DESCRIPTION
This automatically extends support to e.g. `async-std`. For example, the following variant on its `cat` example works
```rust
use std::env::args;

use async_std::fs::File;
use async_std::io;
use async_std::prelude::*;
use async_std::task;

use memmap2::Mmap;

fn main() -> io::Result<()> {
    let path = args().nth(1).expect("missing path argument");

    task::block_on(async {
        let file = File::open(&path).await?;
        let map = unsafe { Mmap::map(&file)? };

        let mut stdout = io::stdout();
        stdout.write_all(&map).await?;
        stdout.flush().await?;

        Ok(())
    })
}
```