### PR TITLE
Explicitly call fstat64

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1185,29 +1185,6 @@ mod test {
         assert_eq!(nulls, &read);
     }
 
-    // 32bit Linux cannot map a file larger than i32, but Windows can.
-    #[cfg(all(target_os = "linux", target_pointer_width = "32"))]
-    #[test]
-    fn map_offset() {
-        let tempdir = tempdir::TempDir::new("mmap").unwrap();
-        let path = tempdir.path().join("mmap");
-
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(&path)
-            .unwrap();
-
-        let offset = u32::max_value() as u64 + 2;
-        let len = 5432;
-        file.set_len(offset + len as u64).unwrap();
-
-        let mmap = unsafe { MmapOptions::new().offset(offset).map_mut(&file) };
-        assert!(mmap.is_err());
-    }
-
-    #[cfg(not(all(target_os = "linux", target_pointer_width = "32")))]
     #[test]
     fn map_offset() {
         let tempdir = tempdir::TempDir::new("mmap").unwrap();


### PR DESCRIPTION
Otherwise, on 32-bit platforms, the length check

```rust
if len > (usize::MAX as u64) {
```

[in `MmapOptions::get_len`](https://github.com/RazrFalcon/memmap2-rs/blob/6d5149fe2070e15775f14587d620f6db1f077158/src/lib.rs#L253) will never evaluate to true [as `libc::stat::st_size` is of type `i32`](https://docs.rs/libc/latest/i686-unknown-linux-gnu/libc/struct.stat.html#structfield.st_size).

Related https://github.com/sunfishcode/mustang/issues/71