### PR TITLE
Avoid creating slices that exceed isize::MAX bytes.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,13 +51,14 @@ use std::fmt;
 #[cfg(not(any(unix, windows)))]
 use std::fs::File;
 use std::io::{Error, ErrorKind, Result};
+use std::isize;
+use std::mem;
 use std::ops::{Deref, DerefMut};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, RawHandle};
 use std::slice;
-use std::usize;
 
 #[cfg(not(any(unix, windows)))]
 pub struct MmapRawDescriptor<'a>(&'a File);
@@ -202,6 +203,10 @@ impl MmapOptions {
     ///
     /// For file-backed memory maps, the length will default to the file length.
     ///
+    /// # Panics
+    ///
+    /// Panics if the given `len` exceeds `isize::MAX` bytes.
+    ///
     /// # Example
     ///
     /// ```
@@ -219,6 +224,13 @@ impl MmapOptions {
     /// # }
     /// ```
     pub fn len(&mut self, len: usize) -> &mut Self {
+        if mem::size_of::<usize>() < 8 {
+            assert!(
+                len < isize::MAX as usize,
+                "memory map length overflows isize"
+            );
+        }
+
         self.len = Some(len);
         self
     }
@@ -237,15 +249,11 @@ impl MmapOptions {
             }
             let len = file_len - self.offset;
 
-            // This check it not relevant on 64bit targets, because usize == u64
-            #[cfg(not(target_pointer_width = "64"))]
-            {
-                if len > (usize::MAX as u64) {
-                    return Err(Error::new(
-                        ErrorKind::InvalidData,
-                        "memory map length overflows usize",
-                    ));
-                }
+            if mem::size_of::<usize>() < 8 && len > isize::MAX as u64 {
+                return Err(Error::new(
+                    ErrorKind::InvalidData,
+                    "memory map length overflows isize",
+                ));
             }
 
             Ok(len as usize)
@@ -857,6 +865,10 @@ impl MmapMut {
     /// # Errors
     ///
     /// This method returns an error when the underlying system call fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given `length` exceeds `isize::MAX` bytes.
     pub fn map_anon(length: usize) -> Result<MmapMut> {
         MmapOptions::new().len(length).map_anon()
     }
@@ -1039,6 +1051,7 @@ mod test {
     use crate::advice::Advice;
     use std::fs::OpenOptions;
     use std::io::{Read, Write};
+    use std::mem;
     #[cfg(unix)]
     use std::os::unix::io::AsRawFd;
     #[cfg(windows)]
@@ -1155,6 +1168,13 @@ mod test {
     #[test]
     fn map_anon_zero_len() {
         assert!(MmapOptions::new().map_anon().unwrap().is_empty())
+    }
+
+    #[test]
+    #[cfg(target_pointer_width = "32")]
+    #[should_panic(expected = "memory map length overflows isize")]
+    fn map_anon_len_overflow() {
+        let _ = MmapMut::map_anon(0x80000000);
     }
 
     #[test]
@@ -1333,7 +1353,6 @@ mod test {
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn jit_x86(mut mmap: MmapMut) {
-        use std::mem;
         mmap[0] = 0xB8; // mov eax, 0xAB
         mmap[1] = 0xAB;
         mmap[2] = 0x00;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,8 +454,9 @@ impl MmapOptions {
 
     /// Creates an anonymous memory map.
     ///
-    /// Note: the memory map length must be configured to be greater than 0 before creating an
-    /// anonymous memory map using `MmapOptions::len()`.
+    /// The memory map length should be configured using [`MmapOptions::len()`]
+    /// before creating an anonymous memory map, otherwise a zero-length mapping
+    /// will be crated.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
I think adding an assertion to `MmapOptions::len` is sufficient to catch all cases leading to erroneously large slice lengths due to the check in `MmapOptions::get_len`. I also think an assertion is appropriate for the setter and its indirect call via `MmapMut::map_anon` so that this is backwards-compatible.

Fixes #48 