### PR TITLE
Add support for mlock() and munlock()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -629,6 +629,22 @@ impl Mmap {
     pub fn advise(&self, advice: Advice) -> Result<()> {
         self.inner.advise(advice)
     }
+
+    /// Lock the whole memory map into RAM. Only supported on Unix.
+    ///
+    /// See [mlock()](https://man7.org/linux/man-pages/man2/mlock.2.html) map page.
+    #[cfg(unix)]
+    pub fn lock(&mut self) -> Result<()> {
+        self.inner.lock()
+    }
+
+    /// Unlock the whole memory map. Only supported on Unix.
+    ///
+    /// See [munlock()](https://man7.org/linux/man-pages/man2/munlock.2.html) map page.
+    #[cfg(unix)]
+    pub fn unlock(&mut self) -> Result<()> {
+        self.inner.unlock()
+    }
 }
 
 #[cfg(feature = "stable_deref_trait")]
@@ -1005,6 +1021,22 @@ impl MmapMut {
     #[cfg(unix)]
     pub fn advise(&self, advice: Advice) -> Result<()> {
         self.inner.advise(advice)
+    }
+
+    /// Lock the whole memory map into RAM. Only supported on Unix.
+    ///
+    /// See [mlock()](https://man7.org/linux/man-pages/man2/mlock.2.html) map page.
+    #[cfg(unix)]
+    pub fn lock(&mut self) -> Result<()> {
+        self.inner.lock()
+    }
+
+    /// Unlock the whole memory map. Only supported on Unix.
+    ///
+    /// See [munlock()](https://man7.org/linux/man-pages/man2/munlock.2.html) map page.
+    #[cfg(unix)]
+    pub fn unlock(&mut self) -> Result<()> {
+        self.inner.unlock()
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -248,6 +248,26 @@ impl MmapInner {
             }
         }
     }
+
+    pub fn lock(&self) -> io::Result<()> {
+        unsafe {
+            if libc::mlock(self.ptr, self.len) != 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    pub fn unlock(&self) -> io::Result<()> {
+        unsafe {
+            if libc::munlock(self.ptr, self.len) != 0 {
+                Err(io::Error::last_os_error())
+            } else {
+                Ok(())
+            }
+        }
+    }
 }
 
 impl Drop for MmapInner {


### PR DESCRIPTION
It is now possible to lock the whole memory into RAM, it won't
be swapped.

Closes #51.

I'll try tomorrow if I can add a test that runs out of memory on CI.