### PR TITLE
Use File::metadata to get file size, not fstat64

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,7 +1,8 @@
 extern crate libc;
 
-use std::mem::MaybeUninit;
-use std::os::unix::io::RawFd;
+use std::fs::File;
+use std::mem::ManuallyDrop;
+use std::os::unix::io::{FromRawFd, RawFd};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{io, ptr};
 
@@ -304,19 +305,10 @@ fn page_size() -> usize {
 }
 
 pub fn file_len(file: RawFd) -> io::Result<u64> {
-    #[cfg(not(any(target_os = "linux", target_os = "emscripten", target_os = "l4re")))]
-    use libc::{fstat, stat};
-    #[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "l4re"))]
-    use libc::{fstat64 as fstat, stat64 as stat};
-
+    // SAFETY: We must not close the passed-in fd by dropping the File we create,
+    // we ensure this by immediately wrapping it in a ManuallyDrop.
     unsafe {
-        let mut stat = MaybeUninit::<stat>::uninit();
-
-        let result = fstat(file, stat.as_mut_ptr());
-        if result == 0 {
-            Ok(stat.assume_init().st_size as u64)
-        } else {
-            Err(io::Error::last_os_error())
-        }
+        let file = ManuallyDrop::new(File::from_raw_fd(file));
+        Ok(file.metadata()?.len())
     }
 }


### PR DESCRIPTION
I can't entirely figure out from git history the justification for why this crate calls `fstat64` directly, so sorry if I'm re-treading ground here.

I'm trying to add `mmap` support to Miri. While trying to figure out how many more unit tests will now run in Miri, I discovered that a large fraction of the callers of `mmap` go through this library, which mostly calls `fstat64` first. That's a big problem for Miri because I don't know how to shim `fstat64`. Miri is a cross-interpreter, so every combination of host+target is supposed to work, and it is entirely unclear how to fill out the fields of a `stat64` when the host is Windows.

So that's why I would very much like to adjust this crate instead of trying to figure out `fstat64` support in Miri. If you accept this patch, it would also be awfully convenient if you cut a new release with it.