### PR TITLE
Specify licenses in SPDX format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "memmap2"
 version = "0.5.7"
 authors = ["Dan Burkert <dan@danburkert.com>", "Yevhenii Reizner <razrfalcon@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/RazrFalcon/memmap2-rs"
 documentation = "https://docs.rs/memmap2"
 description = "Cross-platform Rust API for memory-mapped file IO"


### PR DESCRIPTION
The use of `/` as a separator is deprecated.