### PR TITLE
Stop using deprecated or unmaintained CI dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       env:
         CLIPPY_OPTS: --all-targets -- --allow clippy::len_without_is_empty --allow clippy::missing_safety_doc
       run: |
-        cargo fmt -- --check
+        cargo fmt --check
         cargo clippy $CLIPPY_OPTS
         cargo clippy --target x86_64-pc-windows-gnu $CLIPPY_OPTS
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
       uses: dtolnay/rust-toolchain@stable
       with:
         targets: x86_64-pc-windows-gnu
+        components: clippy, rustfmt
 
     - name: Run checks
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
         cargo clippy --target x86_64-pc-windows-gnu $CLIPPY_OPTS
 
   test-win:
-    runs-on: windows-2019
+    runs-on: windows-latest
     strategy:
       matrix:
         target:
@@ -46,8 +46,8 @@ jobs:
     - name: Run tests
       run: cargo test --all-features
 
-  test-macos-catalina:
-    runs-on: macos-10.15
+  test-macos:
+    runs-on: macos-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
       run: cargo test --all-features
 
   test-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         target:
@@ -77,7 +77,7 @@ jobs:
       run: cargo test --all-features
 
   check-stub:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -94,7 +94,7 @@ jobs:
       run: cargo check --all-features --target wasm32-unknown-unknown
 
   test-msrv:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Set default target
-      run: rustup default stable-${{ matrix.target }}
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable-${{ matrix.target }}
 
     - name: Run tests
       run: cargo test --all-features
@@ -67,8 +69,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Set default target
-      run: rustup default stable-${{ matrix.target }}
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable-${{ matrix.target }}
 
     - name: Install multilib
       if: ${{ matrix.target == 'i686-unknown-linux-gnu' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,11 +13,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        profile: minimal
-        target: x86_64-pc-windows-gnu
+        targets: x86_64-pc-windows-gnu
 
     - name: Run checks
       env:
@@ -83,12 +81,9 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: stable
-        profile: minimal
-        target: wasm32-unknown-unknown
-        override: true
+        targets: wasm32-unknown-unknown
 
     - name: Run check
       run: cargo check --all-features --target wasm32-unknown-unknown
@@ -100,11 +95,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: 1.36.0
-        profile: minimal
-        override: true
+      uses: dtolnay/rust-toolchain@1.36.0
 
     - name: Run tests
       run: cargo test --all-features

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@stable
+
     - name: Run tests
       run: cargo test --all-features
 


### PR DESCRIPTION
The two big items here are:
* `macos-10.15` is deprecated by GitHub actions and will be removed by 2022-08-30, which is in 4 days. Switch all runner images to their `-latest` version, so this won't be a concern again in the foreseeable future.
* The actions-rs organization is unmaintained with the sole member being unresponsive for close to two years. Switch to  `dtolnay/rust-toolchain`.

Best reviewed commit-by-commit.

The update of `actions/checkout` to v3 has been intentionally left out here. Instead of doing a one-time bump, I'll submit a separate PR adding a dependabot config to keep watch over that going forward.