### PR TITLE
Add a dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: Rust
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Dependabot will automatically file PRs for updatable dependencies. The cargo section watches
Cargo.toml. The github-actions section watches the workflow files in .github/workflows for possible
updates to any of the Actions depended upon.
Ignore Dependabot's branches on CI to avoid running the tests twice, once on the push to the branch
and once on the creation of the PR.

See https://github.com/eminence/terminal-size/pull/42 for an example PR you'll also automatically receive after merging this. Kindly merge https://github.com/RazrFalcon/memmap2-rs/pull/56 first to avoid any conflicts.