### PR TITLE
Bump actions/checkout from v2 to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -37,7 +37,7 @@ jobs:
           - x86_64-pc-windows-msvc
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@master
@@ -51,7 +51,7 @@ jobs:
     runs-on: macos-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -68,7 +68,7 @@ jobs:
           - x86_64-unknown-linux-gnu
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@master
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@stable
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Install toolchain
       uses: dtolnay/rust-toolchain@1.36.0


### PR DESCRIPTION
Since you aren't interested in using Dependabot, here's a manual bump.