### PR TITLE
Fix alignment for empty file on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,9 @@ jobs:
 
     - name: Install multilib
       if: ${{ matrix.target == 'i686-unknown-linux-gnu' }}
-      run: sudo apt install gcc-multilib
+      run: |
+        sudo apt update -yqq
+        sudo apt install gcc-multilib
 
     - name: Run tests
       run: cargo test --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1183,6 +1183,7 @@ mod test {
     use crate::advice::Advice;
     use std::fs::{File, OpenOptions};
     use std::io::{Read, Write};
+    use std::mem;
     #[cfg(unix)]
     use std::os::unix::io::AsRawFd;
     #[cfg(windows)]
@@ -1272,8 +1273,10 @@ mod test {
             .unwrap();
         let mmap = unsafe { Mmap::map(&file).unwrap() };
         assert!(mmap.is_empty());
+        assert_eq!(mmap.as_ptr().align_offset(mem::size_of::<usize>()), 0);
         let mmap = unsafe { MmapMut::map_mut(&file).unwrap() };
         assert!(mmap.is_empty());
+        assert_eq!(mmap.as_ptr().align_offset(mem::size_of::<usize>()), 0);
     }
 
     #[test]
@@ -1497,7 +1500,7 @@ mod test {
 
         let mmap = mmap.make_exec().expect("make_exec");
 
-        let jitfn: extern "C" fn() -> u8 = unsafe { std::mem::transmute(mmap.as_ptr()) };
+        let jitfn: extern "C" fn() -> u8 = unsafe { mem::transmute(mmap.as_ptr()) };
         assert_eq!(jitfn(), 0xab);
     }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -132,9 +132,12 @@ extern "system" {
     fn GetSystemInfo(lpSystemInfo: LPSYSTEM_INFO);
 }
 
-/// Returns a fixed pointer that is valid for `slice::from_raw_parts::<u8>` with `len == 0`.
+/// Returns a fixed aligned pointer that is valid for `slice::from_raw_parts::<u8>` with `len == 0`.
+///
+/// This aligns the pointer to `allocation_granularity()` or 1 if unknown.
 fn empty_slice_ptr() -> *mut c_void {
-    std::ptr::NonNull::<u8>::dangling().cast().as_ptr()
+    let align = allocation_granularity().max(1);
+    unsafe { mem::transmute(align) }
 }
 
 pub struct MmapInner {


### PR DESCRIPTION
Fixes <https://github.com/RazrFalcon/memmap2-rs/issues/78>.

Fixes the empty file check on Windows to return a pointer that is aligned to `allocation_granularity()` instead of 1.

This also updates the `map_empty_file()` test to assert for alignment against `usize`. I'm not sure if we can do something better here.

CC: @adamreichold @Jesse-Bakker