### PR TITLE
A few tiny clippy-inspired nits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Run checks
       env:
-        CLIPPY_OPTS: --all-targets -- --allow clippy::len_without_is_empty --allow clippy::missing_safety_doc
+        CLIPPY_OPTS: --all-targets
       run: |
         cargo fmt --check
         cargo clippy $CLIPPY_OPTS

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -2,7 +2,7 @@
 #[allow(unused_imports)]
 use crate::{Mmap, MmapMut};
 
-/// Values supported by [Mmap::advise] and [MmapMut::advise] functions.
+/// Values supported by [`Mmap::advise`] and [`MmapMut::advise`] functions.
 /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
 #[repr(i32)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@
 //! you can use [`MmapOptions`] in order to further configure a mapping
 //! before you create it.
 
+#![allow(clippy::len_without_is_empty, clippy::missing_safety_doc)]
+
 #[cfg_attr(unix, path = "unix.rs")]
 #[cfg_attr(windows, path = "windows.rs")]
 #[cfg_attr(not(any(unix, windows)), path = "stub.rs")]
@@ -771,7 +773,6 @@ impl MmapRaw {
     ///
     /// Note that truncating the file can cause the length to change (and render this value unusable).
     #[inline]
-    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -771,6 +771,7 @@ impl MmapRaw {
     ///
     /// Note that truncating the file can cause the length to change (and render this value unusable).
     #[inline]
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
@@ -1549,7 +1550,7 @@ mod test {
             .open(&path)
             .unwrap();
 
-        let offset = u32::max_value() as u64 + 2;
+        let offset = u32::MAX as u64 + 2;
         let len = 5432;
         file.set_len(offset + len as u64).unwrap();
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -48,7 +48,7 @@ pub struct MmapInner {
 impl MmapInner {
     /// Creates a new `MmapInner`.
     ///
-    /// This is a thin wrapper around the `mmap` sytem call.
+    /// This is a thin wrapper around the `mmap` system call.
     fn new(
         len: usize,
         prot: libc::c_int,
@@ -59,7 +59,7 @@ impl MmapInner {
         let alignment = offset % page_size() as u64;
         let aligned_offset = offset - alignment;
 
-        let (map_len, map_offset) = Self::adjust_mmap_params(len as usize, alignment as usize)?;
+        let (map_len, map_offset) = Self::adjust_mmap_params(len, alignment as usize)?;
 
         unsafe {
             let ptr = mmap(
@@ -197,7 +197,7 @@ impl MmapInner {
         debug_assert!(offset < page_size(), "offset larger than page size");
 
         Self {
-            ptr: ptr.offset(offset as isize),
+            ptr: ptr.add(offset),
             len,
         }
     }


### PR DESCRIPTION
A few tiny clippy-inspired nits

* from_raw_parts pointer arithmetics
* unused usize cast
* markdown cleanup
* `u32::max_value()` is deprecated, replaced with `u32::MAX`
* ~no need to `use isize` -- `isize::MAX` is available without it, and moreover, use isize is marked as deprecated.~ -- turns out 1.36 MSRV is pretty limiting... should it be bumped?