### PR TITLE
Allow arbitrary mapping size for windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1583,6 +1583,35 @@ mod test {
     }
 
     #[test]
+    fn map_len() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("mmap");
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .unwrap();
+
+        let len = 5432;
+
+        // Check explicit length mmap with an empty file.
+        let mmap = unsafe {
+            MmapOptions::new()
+                .len(len)
+                .map_mut(&file)
+                .unwrap()
+        };
+
+        file.set_len(len as u64).unwrap();
+
+        let zeros = vec![0; len];
+        // check that the mmap is readable and empty
+        assert_eq!(&zeros[..], &mmap[..]);
+    }
+
+    #[test]
     fn index() {
         let mut mmap = MmapMut::map_anon(128).unwrap();
         mmap[0] = 42;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -180,7 +180,14 @@ impl MmapInner {
         }
 
         unsafe {
-            let mapping = CreateFileMappingW(handle, ptr::null_mut(), protect, 0, 0, ptr::null());
+            let mapping = CreateFileMappingW(
+                handle,
+                ptr::null_mut(),
+                protect,
+                (aligned_len >> 16 >> 16) as DWORD,
+                (aligned_len & 0xffffffff) as DWORD,
+                ptr::null(),
+            );
             if mapping.is_null() {
                 return Err(io::Error::last_os_error());
             }


### PR DESCRIPTION
It is sometimes useful to reserve additional address space when creating a file mapping so that remapping is not required when the file grows. This currently works for `unix`, but not for `windows`.
