### PR TITLE
Re-add Copy and Clone traits on Advice

### DIFF
--- a/src/advice.rs
+++ b/src/advice.rs
@@ -1,6 +1,6 @@
 /// Values supported by [`Mmap::advise`][crate::Mmap::advise] and [`MmapMut::advise`][crate::MmapMut::advise] functions.
 /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Advice(pub(crate) libc::c_int);
 
 impl Advice {


### PR DESCRIPTION
This reverts the removal of Copy and Clone traits on Advice value from #95

cc: @adamreichold 