### PR TITLE
Separate safe and unsafe madvice flags into separate types to re-enable Copy on the safe ones.

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -6,8 +6,6 @@ use std::os::unix::io::{FromRawFd, RawFd};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{io, ptr};
 
-use crate::advice::Advice;
-
 #[cfg(any(
     all(target_os = "linux", not(target_arch = "mips")),
     target_os = "freebsd",
@@ -342,12 +340,12 @@ impl MmapInner {
         self.len
     }
 
-    pub fn advise(&self, advice: Advice, offset: usize, len: usize) -> io::Result<()> {
+    pub fn advise(&self, advice: libc::c_int, offset: usize, len: usize) -> io::Result<()> {
         let alignment = (self.ptr as usize + offset) % page_size();
         let offset = offset as isize - alignment as isize;
         let len = len + alignment;
         unsafe {
-            if libc::madvise(self.ptr.offset(offset), len, advice.0) != 0 {
+            if libc::madvise(self.ptr.offset(offset), len, advice) != 0 {
                 Err(io::Error::last_os_error())
             } else {
                 Ok(())


### PR DESCRIPTION
This would be my proposal to re-gain `Copy` on the safe advice flags where it does not matter.

As alternatives we could also consider:
* Turning `Advice` back into an enum since all values can be constructed safely.
* Turning both types into an enum and instead of the `AsRawAdvice` trait duplicate all `advice(_range)` methods into `unsafe_advice(_range)` methods which directly take `UnsafeAdvice`.

 