### PR TITLE
use windows-sys for Win32 API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "memmap2"
 version = "0.9.4"
-authors = ["Dan Burkert <dan@danburkert.com>", "Yevhenii Reizner <razrfalcon@gmail.com>"]
+authors = [
+    "Dan Burkert <dan@danburkert.com>",
+    "Yevhenii Reizner <razrfalcon@gmail.com>",
+]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/RazrFalcon/memmap2-rs"
 documentation = "https://docs.rs/memmap2"
@@ -14,6 +17,16 @@ stable_deref_trait = { version = "1.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.151"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Memory",
+    "Win32_System_SystemInformation",
+    "Win32_System_Threading",
+] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Build Status](https://github.com/RazrFalcon/memmap2-rs/workflows/Rust/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/memmap2.svg)](https://crates.io/crates/memmap2)
 [![Documentation](https://docs.rs/memmap2/badge.svg)](https://docs.rs/memmap2)
-[![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-orange.svg)](https://www.rust-lang.org)
+[![Rust 1.56+](https://img.shields.io/badge/rust-1.56+-orange.svg)](https://www.rust-lang.org)
 
 A Rust library for cross-platform memory mapped IO.
 


### PR DESCRIPTION
- use [windows-sys](https://docs.rs/windows-sys) crate for Win32 API (need Rust 1.56+)
- use [MaybeUninit](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html) instead of `&mut T`
- fix `clippy` warnings
- bump minimum supported Rust version to 1.56+