### PR TITLE
Added `MmapOptions::no_reserve` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- Added `MmapOptions::no_reserve` method to support not to reserve swap space for this mapping. Linux only.
 
 ## [0.9.4] - 2024-01-25
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
-- Added `MmapOptions::no_reserve` method to support not to reserve swap space for this mapping. Linux only.
+- Added `MmapOptions::no_reserve` method to support not to reserve memory page or swap space for this mapping.
 
 ## [0.9.4] - 2024-01-25
 ### Changed

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -21,6 +21,12 @@ const MAP_STACK: libc::c_int = libc::MAP_STACK;
 const MAP_STACK: libc::c_int = 0;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
+const MAP_NORESERVE: libc::c_int = libc::MAP_NORESERVE;
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+const MAP_NORESERVE: libc::c_int = 0;
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
 const MAP_POPULATE: libc::c_int = libc::MAP_POPULATE;
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -283,9 +289,11 @@ impl MmapInner {
         len: usize,
         stack: bool,
         populate: bool,
+        no_reserve: bool,
         huge: Option<u8>,
     ) -> io::Result<MmapInner> {
         let stack = if stack { MAP_STACK } else { 0 };
+        let no_reserve = if no_reserve { MAP_NORESERVE } else { 0 };
         let populate = if populate { MAP_POPULATE } else { 0 };
         let hugetlb = if huge.is_some() { MAP_HUGETLB } else { 0 };
         let offset = huge
@@ -294,7 +302,7 @@ impl MmapInner {
         MmapInner::new(
             len,
             libc::PROT_READ | libc::PROT_WRITE,
-            libc::MAP_PRIVATE | libc::MAP_ANON | stack | populate | hugetlb,
+            libc::MAP_PRIVATE | libc::MAP_ANON | stack | no_reserve | populate | hugetlb,
             -1,
             offset,
         )

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -347,6 +347,7 @@ impl MmapInner {
         len: usize,
         _stack: bool,
         _populate: bool,
+        _no_reserve: bool,
         _huge: Option<u8>,
     ) -> io::Result<MmapInner> {
         // Ensure a non-zero length for the underlying mapping


### PR DESCRIPTION
Added `MmapOptions::no_reserve` method to support not to reserve swap space for this mapping. Linux only.