### PR TITLE
Add {Advise, UncheckedAdvice}::is_supported()

### DIFF
--- a/src/advice.rs
+++ b/src/advice.rs
@@ -382,3 +382,41 @@ pub enum UncheckedAdvice {
 // MADV_KEEPONFORK  (since Linux 4.14)
 // MADV_COLD  (since Linux 5.4)
 // MADV_PAGEOUT  (since Linux 5.4)
+
+#[cfg(target_os = "linux")]
+impl Advice {
+    /// Performs a runtime check if this advice is supported by the kernel.
+    /// Only supported on Linux. See the [`madvise(2)`] man page.
+    ///
+    /// [`madvise(2)`]: https://man7.org/linux/man-pages/man2/madvise.2.html#VERSIONS
+    pub fn is_supported(self) -> bool {
+        (unsafe { libc::madvise(std::ptr::null_mut(), 0, self as libc::c_int) }) == 0
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl UncheckedAdvice {
+    /// Performs a runtime check if this advice is supported by the kernel.
+    /// Only supported on Linux. See the [`madvise(2)`] man page.
+    ///
+    /// [`madvise(2)`]: https://man7.org/linux/man-pages/man2/madvise.2.html#VERSIONS
+    pub fn is_supported(self) -> bool {
+        (unsafe { libc::madvise(std::ptr::null_mut(), 0, self as libc::c_int) }) == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_is_supported() {
+        assert!(Advice::Normal.is_supported());
+        assert!(Advice::Random.is_supported());
+        assert!(Advice::Sequential.is_supported());
+        assert!(Advice::WillNeed.is_supported());
+
+        assert!(UncheckedAdvice::DontNeed.is_supported());
+    }
+}


### PR DESCRIPTION
Some Linux-specific advices are supported only on recent kernels, e.g. `MADV_POPULATE_READ` is available starting from Linux 5.14. Some long-term supported distros (e.g. RHEL 8 and Ubuntu 20.04) still have older kernels. So it would be useful to provide a way to perform a runtime check to see whether the specified advice is supported.

This PR adds two similar methods `Advise::is_supported()` and `UncheckedAdvice::is_supported()`. They're marked as Linux-only as:
1. I guess the support for the common (non-Linux) advices should be universal, so there is no need to check.
2. Only Linux have a documented way to check it[^1], see [`madvise(2)`](https://man7.org/linux/man-pages/man2/madvise.2.html#VERSIONS).


[^1]: Tho, as for not officially documented way, I've found this approach for BSDs: https://github.com/jart/cosmopolitan/blob/3.8.0/libc/calls/madvise.c#L38-L39