### PR TITLE
Remove use of legacy numeric constants, use associated constants.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,8 +13,6 @@
     clippy::return_self_not_must_use,
     clippy::unreadable_literal,
     clippy::upper_case_acronyms,
-    // remove later
-    clippy::legacy_numeric_constants
 )]
 
 //! A cross-platform Rust API for memory mapped buffers.
@@ -72,7 +70,6 @@ use std::fmt;
 #[cfg(not(any(unix, windows)))]
 use std::fs::File;
 use std::io::{Error, ErrorKind, Result};
-use std::isize;
 use std::mem;
 use std::ops::{Deref, DerefMut};
 #[cfg(unix)]

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -96,8 +96,6 @@ impl MmapInner {
     }
 
     fn adjust_mmap_params(len: usize, alignment: usize) -> io::Result<(usize, usize)> {
-        use std::isize;
-
         // Rust's slice cannot be larger than isize::MAX.
         // See https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html
         //


### PR DESCRIPTION
Now that we switched to MSVR 1.63 we can also remove the use of `std::isize` constants and use associated consts of `isize` directly :)