### PR TITLE
Remove `extern crate`

### DIFF
--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -1,5 +1,3 @@
-extern crate memmap2;
-
 use std::env;
 use std::fs::File;
 use std::io::{self, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -425,9 +425,6 @@ impl MmapOptions {
     /// # Example
     ///
     /// ```
-    /// # extern crate memmap2;
-    /// # extern crate tempfile;
-    /// #
     /// use std::fs::OpenOptions;
     /// use std::path::PathBuf;
     ///
@@ -680,9 +677,6 @@ impl Mmap {
     /// # Example
     ///
     /// ```
-    /// # extern crate memmap2;
-    /// # extern crate tempfile;
-    /// #
     /// use memmap2::Mmap;
     /// use std::ops::DerefMut;
     /// use std::io::Write;
@@ -892,9 +886,6 @@ impl MmapRaw {
     /// # Example
     ///
     /// ```
-    /// # extern crate memmap2;
-    /// # extern crate tempfile;
-    /// #
     /// use std::fs::OpenOptions;
     /// use std::io::Write;
     /// use std::path::PathBuf;
@@ -1117,9 +1108,6 @@ impl MmapMut {
     /// # Example
     ///
     /// ```
-    /// # extern crate memmap2;
-    /// # extern crate tempfile;
-    /// #
     /// use std::fs::OpenOptions;
     /// use std::path::PathBuf;
     ///
@@ -1168,9 +1156,6 @@ impl MmapMut {
     /// # Example
     ///
     /// ```
-    /// # extern crate memmap2;
-    /// # extern crate tempfile;
-    /// #
     /// use std::fs::OpenOptions;
     /// use std::io::Write;
     /// use std::path::PathBuf;
@@ -1244,8 +1229,6 @@ impl MmapMut {
     /// # Example
     ///
     /// ```
-    /// # extern crate memmap2;
-    /// #
     /// use std::io::Write;
     /// use std::path::PathBuf;
     ///
@@ -1463,8 +1446,6 @@ impl RemapOptions {
 
 #[cfg(test)]
 mod test {
-    extern crate tempfile;
-
     #[cfg(unix)]
     use crate::advice::Advice;
     use std::fs::{File, OpenOptions};
@@ -1968,8 +1949,6 @@ mod test {
     #[test]
     #[cfg(feature = "stable_deref_trait")]
     fn owning_ref() {
-        extern crate owning_ref;
-
         let mut map = MmapMut::map_anon(128).unwrap();
         map[10] = 42;
         let owning = owning_ref::OwningRef::new(map);

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,5 +1,3 @@
-extern crate libc;
-
 use std::fs::File;
 use std::mem::ManuallyDrop;
 use std::os::unix::io::{FromRawFd, RawFd};


### PR DESCRIPTION
[`extern crate` is no longer needed in 99% of circumstances.](https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html)

This PR removes all usages of `extern crate`.