### PR TITLE
Change MSRV badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Build Status](https://github.com/RazrFalcon/memmap2-rs/workflows/Rust/badge.svg)
 [![Crates.io](https://img.shields.io/crates/v/memmap2.svg)](https://crates.io/crates/memmap2)
 [![Documentation](https://docs.rs/memmap2/badge.svg)](https://docs.rs/memmap2)
-[![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-orange.svg)](https://www.rust-lang.org)
+[![MSRV 1.63.0](https://img.shields.io/badge/msrv-1.63.0-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.63.0)
 
 A Rust library for cross-platform memory mapped IO.
 


### PR DESCRIPTION
- version bump
- change badge link to point to the MSRV release notes
- change badge image text from "rust" to "msrv"
- change alt text from "Rust" to "MSRV"
- different styling

The proposed badge is taken from the dotenvy README.

Before:
[![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-orange.svg)](https://www.rust-lang.org)

After:
[![MSRV 1.63.0](https://img.shields.io/badge/msrv-1.63.0-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.63.0)

All badges before:
![Build Status](https://github.com/RazrFalcon/memmap2-rs/workflows/Rust/badge.svg) [![Crates.io](https://img.shields.io/crates/v/memmap2.svg)](https://crates.io/crates/memmap2) [![Documentation](https://docs.rs/memmap2/badge.svg)](https://docs.rs/memmap2) [![Rust 1.36+](https://img.shields.io/badge/rust-1.36+-orange.svg)](https://www.rust-lang.org)

All badges after:
![Build Status](https://github.com/RazrFalcon/memmap2-rs/workflows/Rust/badge.svg) [![Crates.io](https://img.shields.io/crates/v/memmap2.svg)](https://crates.io/crates/memmap2) [![Documentation](https://docs.rs/memmap2/badge.svg)](https://docs.rs/memmap2) [![MSRV 1.63.0](https://img.shields.io/badge/msrv-1.63.0-dea584.svg?logo=rust)](https://github.com/rust-lang/rust/releases/tag/1.63.0)

