### PR TITLE
Complete madvise values

### DIFF
--- a/src/advice.rs
+++ b/src/advice.rs
@@ -193,7 +193,7 @@ pub enum Advice {
     /// about other possible mappings of the memory. In the event
     /// multiple hugepage-aligned/sized areas fail to collapse,
     /// only the most-recently–failed code will be set in errno.
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
     Collapse = libc::MADV_COLLAPSE,
 
     //// **MADV_DONTDUMP** - Linux only (since Linux 3.4)


### PR DESCRIPTION
This PR implements all remaining madvise values specified in the [Linux man page](https://man7.org/linux/man-pages/man2/madvise.2.html).

The following values are added:
1. SOFT_OFFLINE
2. WIPEONFORK
3. KEEPONFORK
4. COLD
5. PAGEOUT
6. COLLAPSE

Values 1-5 were mentioned in a comment for future expansion. COLLAPSE was also found to be missing.

All six values are memory safe. Brief explanations are below:

1. SOFT_OFFLINE: effects do not change the semantics of the calling process.
2. WIPEONFORK: only affects child processes by zeroing memory post-fork.
3. KEEPONFORK: only affects child processes by preserving memory across fork.
4. COLD: indicates pages are unlikely to be accessed soon; non-destructive.
5. PAGEOUT: requests page reclamation; non-destructive.
6. COLLAPSE: consolidates pages into THPs; non-destructive.

I encourage reviewers to verify my safety assumptions.