### PR TITLE
Bump version to 0.9.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.9.6] - 2025-05-14
 ### Fixed
 - Fix huge page mappings with non-default page-bits.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.6"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Yevhenii Reizner <razrfalcon@gmail.com>",


### PR DESCRIPTION
I think we should release `v0.9.6` with the fix from #141.

There are more things we should pick up, but this fix seems rather important to get out.