### PR TITLE
Add Drop to the docs for Mmap, MmapMut, MmapRaw

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,6 +823,13 @@ impl fmt::Debug for Mmap {
     }
 }
 
+impl Drop for Mmap {
+    fn drop(&mut self) {
+        // unmap gets called by MmapInner's drop.
+        // This is just so that Drop shows up in the docs.
+    } 
+}
+
 /// A handle to a raw memory mapped buffer.
 ///
 /// This struct never hands out references to its interior, only raw pointers.
@@ -1046,6 +1053,13 @@ impl fmt::Debug for MmapRaw {
             .field("len", &self.len())
             .finish()
     }
+}
+
+impl Drop for MmapRaw {
+    fn drop(&mut self) {
+        // unmap gets called by MmapInner's drop.
+        // This is just so that Drop shows up in the docs.
+    } 
 }
 
 impl From<Mmap> for MmapRaw {
@@ -1397,6 +1411,13 @@ impl fmt::Debug for MmapMut {
             .field("len", &self.len())
             .finish()
     }
+}
+
+impl Drop for MmapMut {
+    fn drop(&mut self) {
+        // unmap gets called by MmapInner's drop.
+        // This is just so that Drop shows up in the docs.
+    } 
 }
 
 /// Options for [`Mmap::remap`] and [`MmapMut::remap`].


### PR DESCRIPTION
I was confused about this when I was reading the docs, and it took me a while to realize what was going on. MmapInner correctly calls munmap when dropped, but it doesn't show up in docs, since Mmap doesn't implement Drop directly.

Does it make sense to add empty Drop impls just so that it shows up in the docs?

Related: https://github.com/RazrFalcon/memmap2-rs/issues/140