### PR TITLE
Added support for named but not file backed memory maps on windows.

### DIFF
--- a/src/stub.rs
+++ b/src/stub.rs
@@ -40,6 +40,10 @@ impl MmapInner {
         MmapInner::new()
     }
 
+    pub fn map_named(_: &str, _: usize) -> io::Result<MmapInner> {
+        MmapInner::new()
+    }
+
     pub fn flush(&self, _: usize, _: usize) -> io::Result<()> {
         match self.never {}
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -274,6 +274,10 @@ impl MmapInner {
         )
     }
 
+    pub fn map_named(name: &str, len: usize) -> io::Result<MmapInner> {
+        panic!("named non-file-backed memory maps are not supported on linux")
+    }
+
     /// Open an anonymous memory map.
     pub fn map_anon(
         len: usize,

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -343,12 +343,20 @@ impl MmapInner {
         Ok(inner)
     }
 
+    pub fn map_named(name: &str, len: usize) -> io::Result<MmapInner> {
+        Self::map_non_backed(len, Some(name))
+    }
+
     pub fn map_anon(
         len: usize,
         _stack: bool,
         _populate: bool,
         _huge: Option<u8>,
     ) -> io::Result<MmapInner> {
+        Self::map_non_backed(len, None)
+    }
+
+    fn map_non_backed(len: usize, name: Option<&str>) -> io::Result<MmapInner> {
         // Ensure a non-zero length for the underlying mapping
         let mapped_len = len.max(1);
         unsafe {
@@ -357,13 +365,23 @@ impl MmapInner {
             // on.
             // Also see https://msdn.microsoft.com/en-us/library/windows/desktop/aa366537.aspx
 
+            // The name needs to be converted to UTF16 and null terminated.
+            let utf16_term_name = name.map(|n| {
+                let mut name_buff = n.encode_utf16().collect::<Vec<_>>();
+                name_buff.push(0);
+                name_buff
+            });
+            let lpName = utf16_term_name
+                .map(|n| n.as_ptr() as LPCWSTR)
+                .unwrap_or(ptr::null());
+
             let mapping = CreateFileMappingW(
                 INVALID_HANDLE_VALUE,
                 ptr::null_mut(),
                 PAGE_EXECUTE_READWRITE,
                 (mapped_len >> 16 >> 16) as DWORD,
                 (mapped_len & 0xffffffff) as DWORD,
-                ptr::null(),
+                lpName,
             );
             if mapping.is_null() {
                 return Err(io::Error::last_os_error());


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-createfilemappingw , this is to add some form of accessing memory maps created via the dotnet call https://learn.microsoft.com/en-us/dotnet/api/system.io.memorymappedfiles.memorymappedfile.createnew?view=net-9.0

I kept the existing pattern of implementing both sides of the unix and windows apis, although there is no equivalent in linux so that panics. This isn't a great solution, let me know if you'd prefer a different pattern.
