### PR TITLE
Return `ErrorKind::Unsupported` from stub implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -402,7 +402,7 @@ impl MmapOptions {
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file is not open with read permissions.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     ///
     /// # Example
     ///
@@ -449,7 +449,7 @@ impl MmapOptions {
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file is not open with read permissions.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     pub unsafe fn map_exec<T: MmapAsRawDesc>(&self, file: T) -> Result<Mmap> {
         let desc = file.as_raw_desc();
 
@@ -474,7 +474,7 @@ impl MmapOptions {
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file is not open with read and write permissions.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     ///
     /// # Example
     ///
@@ -526,7 +526,7 @@ impl MmapOptions {
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file is not open with writable permissions.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     ///
     /// # Example
     ///
@@ -566,7 +566,7 @@ impl MmapOptions {
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file is not open with read permissions.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     ///
     /// # Example
     ///
@@ -613,7 +613,7 @@ impl MmapOptions {
     /// This method returns an error when the underlying system call fails or
     /// when `len > isize::MAX`.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     pub fn map_anon(&self) -> Result<MmapMut> {
         let len = self.len.unwrap_or(0);
 
@@ -637,7 +637,7 @@ impl MmapOptions {
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file is not open with read and write permissions.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     pub fn map_raw<T: MmapAsRawDesc>(&self, file: T) -> Result<MmapRaw> {
         let desc = file.as_raw_desc();
 
@@ -660,7 +660,7 @@ impl MmapOptions {
     ///
     /// This method returns an error when the underlying system call fails.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     pub fn map_raw_read_only<T: MmapAsRawDesc>(&self, file: T) -> Result<MmapRaw> {
         let desc = file.as_raw_desc();
 
@@ -736,7 +736,7 @@ impl Mmap {
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file is not open with read permissions.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     ///
     /// # Example
     ///
@@ -941,7 +941,7 @@ impl MmapRaw {
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file is not open with read and write permissions.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     pub fn map_raw<T: MmapAsRawDesc>(file: T) -> Result<MmapRaw> {
         MmapOptions::new().map_raw(file)
     }
@@ -1204,7 +1204,7 @@ impl MmapMut {
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file is not open with read and write permissions.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     ///
     /// # Example
     ///
@@ -1245,7 +1245,7 @@ impl MmapMut {
     /// This method returns an error when the underlying system call fails or
     /// when `len > isize::MAX`.
     ///
-    /// Will return [`ErrorKind::Unsupported`] on unsupported platforms.
+    /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
     pub fn map_anon(length: usize) -> Result<MmapMut> {
         MmapOptions::new().len(length).map_anon()
     }

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -10,7 +10,7 @@ pub struct MmapInner {
 
 impl MmapInner {
     fn new() -> io::Result<MmapInner> {
-        Err(io::Error::from(io::ErrorKind::Unsupported))
+        Err(io::ErrorKind::Unsupported.into())
     }
 
     pub fn map(_: usize, _: &File, _: u64, _: bool, _: bool) -> io::Result<MmapInner> {


### PR DESCRIPTION
I'm sure the documentation could be a bit more succinct, I'm happy to take any advice.

Fixes #160.