### PR TITLE
Fix unchecked pointer math

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Install toolchain
-      uses: dtolnay/rust-toolchain@1.63.0
+      uses: dtolnay/rust-toolchain@1.65.0
 
     # do not test, because dev-dependencies do not follow MSRV
     - name: Build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/memmap2"
 description = "Cross-platform Rust API for memory-mapped file IO"
 keywords = ["mmap", "memory-map", "io", "file"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 
 [dependencies]
 stable_deref_trait = { version = "1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all, clippy::pedantic)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(
     // pedantic exceptions
     clippy::cast_possible_truncation,
@@ -759,7 +760,8 @@ impl Mmap {
     /// # }
     /// ```
     pub unsafe fn map<T: MmapAsRawDesc>(file: T) -> Result<Mmap> {
-        MmapOptions::new().map(file)
+        // SAFETY: safety requirements forwarded to caller.
+        unsafe { MmapOptions::new().map(file) }
     }
 
     /// Transition the memory map to be writable.
@@ -809,8 +811,11 @@ impl Mmap {
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
     pub fn advise(&self, advice: Advice) -> Result<()> {
-        self.inner
-            .advise(advice as libc::c_int, 0, self.inner.len())
+        // SAFETY: The `Advice` enum only allows safe advice values.
+        unsafe {
+            self.inner
+                .advise(advice as libc::c_int, 0, self.inner.len())
+        }
     }
 
     /// Advise OS how this memory map will be accessed.
@@ -818,10 +823,18 @@ impl Mmap {
     /// Used with the [unchecked flags][UncheckedAdvice]. Only supported on Unix.
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
+    ///
+    /// # Safety
+    /// This function can modify the memory map in ways that do not fit in Rust's safe memory access model.
+    /// Care must be taken not to break the soundness rules of the Rust compiler.
+    /// Refer to the operating system documentation to see what each of the [`UncheckedAdvice`] variant does.
     #[cfg(unix)]
     pub unsafe fn unchecked_advise(&self, advice: UncheckedAdvice) -> Result<()> {
-        self.inner
-            .advise(advice as libc::c_int, 0, self.inner.len())
+        // SAFETY: safety requirements forwarded to caller.
+        unsafe {
+            self.inner
+                .advise(advice as libc::c_int, 0, self.inner.len())
+        }
     }
 
     /// Advise OS how this range of memory map will be accessed.
@@ -833,7 +846,8 @@ impl Mmap {
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
     pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
-        self.inner.advise(advice as libc::c_int, offset, len)
+        // SAFETY: The `Advice` enum only allows safe advice values.
+        unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
 
     /// Advise OS how this range of memory map will be accessed.
@@ -843,6 +857,11 @@ impl Mmap {
     /// The offset and length must be in the bounds of the memory map.
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
+    ///
+    /// # Safety
+    /// This function can modify the memory map in ways that do not fit in Rust's safe memory access model.
+    /// Care must be taken not to break the soundness rules of the Rust compiler.
+    /// Refer to the operating system documentation to see what each of the [`UncheckedAdvice`] variant does.
     #[cfg(unix)]
     pub unsafe fn unchecked_advise_range(
         &self,
@@ -850,7 +869,8 @@ impl Mmap {
         offset: usize,
         len: usize,
     ) -> Result<()> {
-        self.inner.advise(advice as libc::c_int, offset, len)
+        // SAFETY: safety requirements forwarded to caller.
+        unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
 
     /// Lock the whole memory map into RAM. Only supported on Unix.
@@ -1055,8 +1075,11 @@ impl MmapRaw {
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
     pub fn advise(&self, advice: Advice) -> Result<()> {
-        self.inner
-            .advise(advice as libc::c_int, 0, self.inner.len())
+        // SAFETY: The `Advice` enum only allows safe advice values.
+        unsafe {
+            self.inner
+                .advise(advice as libc::c_int, 0, self.inner.len())
+        }
     }
 
     /// Advise OS how this memory map will be accessed.
@@ -1064,10 +1087,18 @@ impl MmapRaw {
     /// Used with the [unchecked flags][UncheckedAdvice]. Only supported on Unix.
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
+    ///
+    /// # Safety
+    /// This function can modify the memory map in ways that do not fit in Rust's safe memory access model.
+    /// Care must be taken not to break the soundness rules of the Rust compiler.
+    /// Refer to the operating system documentation to see what each of the [`UncheckedAdvice`] variant does.
     #[cfg(unix)]
     pub unsafe fn unchecked_advise(&self, advice: UncheckedAdvice) -> Result<()> {
-        self.inner
-            .advise(advice as libc::c_int, 0, self.inner.len())
+        // SAFETY: safety requirements forwarded to caller.
+        unsafe {
+            self.inner
+                .advise(advice as libc::c_int, 0, self.inner.len())
+        }
     }
 
     /// Advise OS how this range of memory map will be accessed.
@@ -1079,7 +1110,8 @@ impl MmapRaw {
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
     pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
-        self.inner.advise(advice as libc::c_int, offset, len)
+        // SAFETY: The `Advice` enum only allows safe advice values.
+        unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
 
     /// Advise OS how this range of memory map will be accessed.
@@ -1089,6 +1121,11 @@ impl MmapRaw {
     /// The offset and length must be in the bounds of the memory map.
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
+    ///
+    /// # Safety
+    /// This function can modify the memory map in ways that do not fit in Rust's safe memory access model.
+    /// Care must be taken not to break the soundness rules of the Rust compiler.
+    /// Refer to the operating system documentation to see what each of the [`UncheckedAdvice`] variant does.
     #[cfg(unix)]
     pub unsafe fn unchecked_advise_range(
         &self,
@@ -1096,7 +1133,8 @@ impl MmapRaw {
         offset: usize,
         len: usize,
     ) -> Result<()> {
-        self.inner.advise(advice as libc::c_int, offset, len)
+        // SAFETY: safety requirements forwarded to caller.
+        unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
 
     /// Lock the whole memory map into RAM. Only supported on Unix.
@@ -1233,7 +1271,8 @@ impl MmapMut {
     /// # }
     /// ```
     pub unsafe fn map_mut<T: MmapAsRawDesc>(file: T) -> Result<MmapMut> {
-        MmapOptions::new().map_mut(file)
+        // SAFETY: safety requirements forwarded to caller.
+        unsafe { MmapOptions::new().map_mut(file) }
     }
 
     /// Creates an anonymous memory map.
@@ -1377,8 +1416,11 @@ impl MmapMut {
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
     pub fn advise(&self, advice: Advice) -> Result<()> {
-        self.inner
-            .advise(advice as libc::c_int, 0, self.inner.len())
+        // SAFETY: The `Advice` enum only allows safe advice values.
+        unsafe {
+            self.inner
+                .advise(advice as libc::c_int, 0, self.inner.len())
+        }
     }
 
     /// Advise OS how this memory map will be accessed.
@@ -1388,8 +1430,11 @@ impl MmapMut {
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
     pub unsafe fn unchecked_advise(&self, advice: UncheckedAdvice) -> Result<()> {
-        self.inner
-            .advise(advice as libc::c_int, 0, self.inner.len())
+        // SAFETY: Safety requirements pushed to caller.
+        unsafe {
+            self.inner
+                .advise(advice as libc::c_int, 0, self.inner.len())
+        }
     }
 
     /// Advise OS how this range of memory map will be accessed.
@@ -1401,7 +1446,8 @@ impl MmapMut {
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
     pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
-        self.inner.advise(advice as libc::c_int, offset, len)
+        // SAFETY: The `Advice` enum only allows safe advice values.
+        unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
 
     /// Advise OS how this range of memory map will be accessed.
@@ -1418,7 +1464,8 @@ impl MmapMut {
         offset: usize,
         len: usize,
     ) -> Result<()> {
-        self.inner.advise(advice as libc::c_int, offset, len)
+        // SAFETY: Safety requirements pushed to caller.
+        unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
 
     /// Lock the whole memory map into RAM. Only supported on Unix.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -985,7 +985,7 @@ impl MmapRaw {
     /// but will cause SIGBUS (or equivalent) signal.
     #[inline]
     pub fn as_mut_ptr(&self) -> *mut u8 {
-        self.inner.ptr() as *mut u8
+        self.inner.ptr().cast_mut()
     }
 
     /// Returns the length in bytes of the memory map.

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,8 +1,8 @@
 use std::fs::File;
+use std::io;
 use std::mem::ManuallyDrop;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::{io, ptr};
 
 #[cfg(any(
     all(target_os = "linux", not(target_arch = "mips")),
@@ -95,21 +95,25 @@ impl MmapInner {
 
         let (map_len, map_offset) = Self::adjust_mmap_params(len, alignment as usize)?;
 
-        unsafe {
-            let ptr = mmap(
-                ptr::null_mut(),
+        // SAFETY: creating a new memory map with a nullptr as address hint is always sound:
+        // it does not modify any existing mapping or memory contents.
+        let ptr = unsafe {
+            mmap(
+                std::ptr::null_mut(),
                 map_len as libc::size_t,
                 prot,
                 flags,
                 file,
                 aligned_offset as off_t,
-            );
+            )
+        };
 
-            if ptr == libc::MAP_FAILED {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(Self::from_raw_parts(ptr, len, map_offset))
-            }
+        if ptr == libc::MAP_FAILED {
+            Err(io::Error::last_os_error())
+        } else {
+            // SAFETY: The ptr and len have been checked,
+            // and the offset has been calculated as required.
+            Ok(unsafe { Self::from_raw_parts(ptr, len, map_offset) })
         }
     }
 
@@ -211,7 +215,11 @@ impl MmapInner {
         if len == 0 {
             (self.ptr, 1, 0)
         } else {
-            (unsafe { self.ptr.offset(-(offset as isize)) }, len, offset)
+            let offset = self.ptr as usize % page_size();
+            // SAFETY: MmapInner guarantees that rounding `self.ptr` down to a page boundary gives the real address of the memory map.
+            // This means that it points into the same allocation as `self.ptr`.
+            let ptr = unsafe { self.ptr.sub(offset) };
+            (ptr, len, offset)
         }
     }
 
@@ -229,7 +237,7 @@ impl MmapInner {
         debug_assert!(offset < page_size(), "offset larger than page size");
 
         Self {
-            ptr: ptr.add(offset),
+            ptr: unsafe { ptr.add(offset) },
             len,
         }
     }
@@ -355,10 +363,14 @@ impl MmapInner {
     }
 
     pub fn flush(&self, offset: usize, len: usize) -> io::Result<()> {
+        if offset > self.len || len > self.len - offset {
+            return Err(io::ErrorKind::InvalidInput.into());
+        }
         let alignment = (self.ptr as usize + offset) % page_size();
         let offset = offset as isize - alignment as isize;
         let len = len + alignment;
         let result =
+            // SAFETY: We've checked that offset and len fall within the mapped region.
             unsafe { libc::msync(self.ptr.offset(offset), len as libc::size_t, libc::MS_SYNC) };
         if result == 0 {
             Ok(())
@@ -368,10 +380,14 @@ impl MmapInner {
     }
 
     pub fn flush_async(&self, offset: usize, len: usize) -> io::Result<()> {
+        if offset > self.len || len > self.len - offset {
+            return Err(io::ErrorKind::InvalidInput.into());
+        }
         let alignment = (self.ptr as usize + offset) % page_size();
         let offset = offset as isize - alignment as isize;
         let len = len + alignment;
         let result =
+            // SAFETY: We've checked that offset and len fall within the mapped region.
             unsafe { libc::msync(self.ptr.offset(offset), len as libc::size_t, libc::MS_ASYNC) };
         if result == 0 {
             Ok(())
@@ -381,16 +397,17 @@ impl MmapInner {
     }
 
     fn mprotect(&mut self, prot: libc::c_int) -> io::Result<()> {
-        unsafe {
-            let alignment = self.ptr as usize % page_size();
-            let ptr = self.ptr.offset(-(alignment as isize));
-            let len = self.len + alignment;
-            let len = len.max(1);
-            if libc::mprotect(ptr, len, prot) == 0 {
-                Ok(())
-            } else {
-                Err(io::Error::last_os_error())
-            }
+        let alignment = self.ptr as usize % page_size();
+        // SAFETY: rounding self.ptr down to the previous page boundary gives the pointer of the actual memory map.
+        let ptr = unsafe { self.ptr.sub(alignment) };
+        let len = self.len + alignment;
+        let len = len.max(1);
+
+        // SAFETY: the contract of MmapInner guarantees ptr and len are valid.
+        if unsafe { libc::mprotect(ptr, len, prot) } == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
         }
     }
 
@@ -421,29 +438,34 @@ impl MmapInner {
         self.len
     }
 
-    pub fn advise(&self, advice: libc::c_int, offset: usize, len: usize) -> io::Result<()> {
+    /// Perform an `madvise()`.
+    ///
+    /// # Safety
+    ///
+    /// Some `advise` values can be unsound depending on the situation.
+    /// It is up to the caller to only perform sound madvise() calls on the memory range.
+    pub unsafe fn advise(&self, advice: libc::c_int, offset: usize, len: usize) -> io::Result<()> {
+        if offset > self.len || len > self.len {
+            return Err(std::io::ErrorKind::InvalidInput.into());
+        }
         let alignment = (self.ptr as usize + offset) % page_size();
         let offset = offset as isize - alignment as isize;
         let len = len + alignment;
-        unsafe {
-            let ptr = {
-                // The AIX signature of 'madvise()' differs from the POSIX
-                // specification, which expects 'void *' as the type of the
-                // 'addr' argument, whereas AIX uses 'caddr_t' (i.e., 'char *').
-                #[cfg(target_os = "aix")]
-                {
-                    self.ptr.offset(offset) as *mut u8
-                }
-                #[cfg(not(target_os = "aix"))]
-                {
-                    self.ptr.offset(offset)
-                }
-            };
-            if libc::madvise(ptr, len, advice) != 0 {
-                Err(io::Error::last_os_error())
-            } else {
-                Ok(())
-            }
+
+        // SAFETY: We've checked that offset is within the mapped region.
+        let ptr = unsafe { self.ptr.offset(offset) };
+
+        // The AIX signature of 'madvise()' differs from the POSIX
+        // specification, which expects 'void *' as the type of the
+        // 'addr' argument, whereas AIX uses 'caddr_t' (i.e., 'char *').
+        #[cfg(target_os = "aix")]
+        let ptr = self.ptr.offset(offset).cast();
+
+        // SAFETY: ptr and len are valid. The burden of giving a safe `advice` value is on the caller.
+        if unsafe { libc::madvise(ptr, len, advice) } != 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
         }
     }
 
@@ -452,16 +474,19 @@ impl MmapInner {
         let (old_ptr, old_len, offset) = self.as_mmap_params();
         let (map_len, offset) = Self::adjust_mmap_params(new_len, offset)?;
 
-        unsafe {
-            let new_ptr = libc::mremap(old_ptr, old_len, map_len, options.into_flags());
+        // SAFETY: we hold a mutable reference to self, so we can adjust the location and size of the mapping.
+        let new_ptr = unsafe { libc::mremap(old_ptr, old_len, map_len, options.into_flags()) };
 
-            if new_ptr == libc::MAP_FAILED {
-                Err(io::Error::last_os_error())
-            } else {
-                // We explicitly don't drop self since the pointer within is no longer valid.
-                ptr::write(self, Self::from_raw_parts(new_ptr, new_len, offset));
-                Ok(())
-            }
+        if new_ptr == libc::MAP_FAILED {
+            Err(io::Error::last_os_error())
+        } else {
+            // SAFETY: The pointer and length passed to `from_raw_parts` have just been obtained from a real map, so they must be valid.
+            let new_map = unsafe { Self::from_raw_parts(new_ptr, new_len, offset) };
+            // We explicitly don't drop self since the pointer within is no longer valid.
+            // Instead, swap the new map into `self` and forget the old one.
+            let old_map = std::mem::replace(self, new_map);
+            std::mem::forget(old_map);
+            Ok(())
         }
     }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -160,7 +160,7 @@ impl MmapInner {
         copy: bool,
     ) -> io::Result<MmapInner> {
         let alignment = offset % allocation_granularity() as u64;
-        let aligned_offset = offset - alignment as u64;
+        let aligned_offset = offset - alignment;
         let aligned_len = len + alignment as usize;
         if aligned_len == 0 {
             // `CreateFileMappingW` documents:
@@ -179,27 +179,30 @@ impl MmapInner {
             });
         }
 
-        unsafe {
-            let mapping = CreateFileMappingW(handle, ptr::null_mut(), protect, 0, 0, ptr::null());
-            if mapping.is_null() {
-                return Err(io::Error::last_os_error());
-            }
+        let mapping =
+            unsafe { CreateFileMappingW(handle, ptr::null_mut(), protect, 0, 0, ptr::null()) };
+        if mapping.is_null() {
+            return Err(io::Error::last_os_error());
+        }
 
-            let ptr = MapViewOfFile(
+        let ptr = unsafe {
+            MapViewOfFile(
                 mapping,
                 access,
                 (aligned_offset >> 16 >> 16) as DWORD,
                 (aligned_offset & 0xffffffff) as DWORD,
                 aligned_len as SIZE_T,
-            );
-            CloseHandle(mapping);
-            if ptr.is_null() {
-                return Err(io::Error::last_os_error());
-            }
+            )
+        };
+        unsafe { CloseHandle(mapping) };
+        if ptr.is_null() {
+            return Err(io::Error::last_os_error());
+        }
 
-            let mut new_handle = 0 as RawHandle;
-            let cur_proc = GetCurrentProcess();
-            let ok = DuplicateHandle(
+        let mut new_handle = 0 as RawHandle;
+        let cur_proc = unsafe { GetCurrentProcess() };
+        let ok = unsafe {
+            DuplicateHandle(
                 cur_proc,
                 handle,
                 cur_proc,
@@ -207,19 +210,22 @@ impl MmapInner {
                 0,
                 0,
                 DUPLICATE_SAME_ACCESS,
-            );
-            if ok == 0 {
-                UnmapViewOfFile(ptr);
-                return Err(io::Error::last_os_error());
-            }
-
-            Ok(MmapInner {
-                handle: Some(new_handle),
-                ptr: ptr.offset(alignment as isize),
-                len,
-                copy,
-            })
+            )
+        };
+        if ok == 0 {
+            unsafe { UnmapViewOfFile(ptr) };
+            return Err(io::Error::last_os_error());
         }
+
+        // SAFETY: The mapping is guaranteed to contain at-least `alignment` bytes.
+        let ptr = unsafe { ptr.add(alignment as usize) };
+
+        Ok(MmapInner {
+            handle: Some(new_handle),
+            ptr,
+            len,
+            copy,
+        })
     }
 
     pub fn map(
@@ -411,10 +417,17 @@ impl MmapInner {
     }
 
     pub fn flush_async(&self, offset: usize, len: usize) -> io::Result<()> {
+        if offset > self.len || len > self.len - offset {
+            return Err(io::ErrorKind::InvalidInput.into());
+        }
         if self.ptr == empty_slice_ptr() {
             return Ok(());
         }
-        let result = unsafe { FlushViewOfFile(self.ptr.add(offset), len as SIZE_T) };
+        // SAFETY: We've checked that offset and offset + len fall within the mapped region.
+        let result = unsafe {
+            let ptr = self.ptr.add(offset);
+            FlushViewOfFile(ptr, len as SIZE_T)
+        };
         if result != 0 {
             Ok(())
         } else {
@@ -426,19 +439,19 @@ impl MmapInner {
         if self.ptr == empty_slice_ptr() {
             return Ok(());
         }
-        unsafe {
-            let alignment = self.ptr as usize % allocation_granularity();
-            let ptr = self.ptr.offset(-(alignment as isize));
-            let aligned_len = self.len as SIZE_T + alignment as SIZE_T;
+        let alignment = self.ptr as usize % allocation_granularity();
+        // SAFETY: self.ptr rounded down to `allocation_granularity()` is the real start of the memory map.
+        // So it lies within the same allocation as `self.ptr`.
+        let ptr = unsafe { self.ptr.sub(alignment) };
+        let aligned_len = self.len as SIZE_T + alignment as SIZE_T;
 
-            let mut old = 0;
-            let result = VirtualProtect(ptr, aligned_len, protect, &mut old);
+        let mut old = 0;
+        let result = unsafe { VirtualProtect(ptr, aligned_len, protect, &mut old) };
 
-            if result != 0 {
-                Ok(())
-            } else {
-                Err(io::Error::last_os_error())
-            }
+        if result != 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
         }
     }
 
@@ -484,11 +497,13 @@ impl Drop for MmapInner {
             return;
         }
         let alignment = self.ptr as usize % allocation_granularity();
+        // SAFETY: self.ptr rounded down to `allocation_granularity()` is the real start of the memory map.
+        // So it lies within the same allocation as `self.ptr`.
+        let ptr = unsafe { self.ptr.sub(alignment) };
         // Any errors during unmapping/closing are ignored as the only way
         // to report them would be through panicking which is highly discouraged
         // in Drop impls, c.f. https://github.com/rust-lang/lang-team/issues/97
         unsafe {
-            let ptr = self.ptr.offset(-(alignment as isize));
             UnmapViewOfFile(ptr);
 
             if let Some(handle) = self.handle {


### PR DESCRIPTION
As reported in #169.

As part of the fix, I also split the unsafe blocks into smaller bits, so that each one can have a safety comment. I didn't add safety comments to all of them though, especially on the Windows implementation.

Also bumps the MSRV to 1.65 to follow libc.

/edit: And I enabled `#![deny(unsafe_op_in_unsafe_fn)]` at the crate root to motivate us to put more safety comments where appropriate.