### PR TITLE
Add mmap_if_safe()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,6 +603,40 @@ impl MmapOptions {
         .map(|inner| Mmap { inner })
     }
 
+    /// Creates a read-only memory map backed by a file, after
+    /// verifying that the backing file is immutable.
+    ///
+    /// Unlike [`map()`], this method is not `unsafe` because it verifies that
+    /// the underlying file cannot be modified or truncated. The mapped region
+    /// must fit within the current file size.
+    ///
+    /// Returns `Ok(None)` if the file cannot be proven immutable (including
+    /// on platforms where this check is not supported). Returns `Err` only
+    /// for unexpected I/O errors.
+    ///
+    /// Currently, immutability is recognized on Linux, Android, and FreeBSD
+    /// via:
+    ///
+    /// - A memfd sealed with at least `F_SEAL_SHRINK` and `F_SEAL_WRITE`, or
+    /// - A file with fs-verity enabled (Linux and Android only).
+    ///
+    /// [`map()`]: MmapOptions::map()
+    pub fn map_if_safe<T: MmapAsRawDesc>(&self, file: T) -> Result<Option<Mmap>> {
+        let desc = file.as_raw_desc();
+        let len = self.get_len(&file)?;
+        if !MmapInner::check_safe_to_map(desc.0, self.offset, len)? {
+            return Ok(None);
+        }
+        MmapInner::map(
+            len,
+            desc.0,
+            self.offset,
+            self.populate,
+            self.no_reserve_swap,
+        )
+        .map(|inner| Some(Mmap { inner }))
+    }
+
     /// Creates an anonymous memory map.
     ///
     /// The memory map length should be configured using [`MmapOptions::len()`]
@@ -762,6 +796,15 @@ impl Mmap {
     pub unsafe fn map<T: MmapAsRawDesc>(file: T) -> Result<Mmap> {
         // SAFETY: safety requirements forwarded to caller.
         unsafe { MmapOptions::new().map(file) }
+    }
+
+    /// Creates a read-only memory map backed by a file, verifying that the
+    /// file is immutable.
+    ///
+    /// This is equivalent to calling `MmapOptions::new().map_if_safe(file)`.
+    /// See [`MmapOptions::map_if_safe()`] for details.
+    pub fn map_if_safe<T: MmapAsRawDesc>(file: T) -> Result<Option<Mmap>> {
+        MmapOptions::new().map_if_safe(file)
     }
 
     /// Transition the memory map to be writable.
@@ -2312,6 +2355,153 @@ mod test {
 
         // Check that the mmap is still writable along the slice length
         mmap.copy_from_slice(&incr);
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    fn map_if_safe_sealed_memfd() {
+        use std::io::Write;
+        use std::os::unix::io::FromRawFd;
+
+        let fd = unsafe {
+            libc::memfd_create(
+                b"test\0".as_ptr().cast::<libc::c_char>(),
+                libc::MFD_ALLOW_SEALING,
+            )
+        };
+        if fd < 0 {
+            eprintln!("skipping: memfd_create not supported");
+            return;
+        }
+        let mut file = unsafe { File::from_raw_fd(fd) };
+
+        file.write_all(b"Hello, world!").unwrap();
+
+        // Should return None without seals
+        assert!(Mmap::map_if_safe(&file).unwrap().is_none());
+
+        // Should return None with only F_SEAL_SHRINK
+        unsafe { libc::fcntl(file.as_raw_fd(), libc::F_ADD_SEALS, libc::F_SEAL_SHRINK) };
+        assert!(Mmap::map_if_safe(&file).unwrap().is_none());
+
+        // Should succeed with both seals
+        unsafe { libc::fcntl(file.as_raw_fd(), libc::F_ADD_SEALS, libc::F_SEAL_WRITE) };
+        let mmap = Mmap::map_if_safe(&file).unwrap().unwrap();
+        assert_eq!(&mmap[..], b"Hello, world!");
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    fn map_if_safe_with_offset() {
+        use std::io::Write;
+        use std::os::unix::io::FromRawFd;
+
+        let fd = unsafe {
+            libc::memfd_create(
+                b"test\0".as_ptr().cast::<libc::c_char>(),
+                libc::MFD_ALLOW_SEALING,
+            )
+        };
+        if fd < 0 {
+            eprintln!("skipping: memfd_create not supported");
+            return;
+        }
+        let mut file = unsafe { File::from_raw_fd(fd) };
+
+        file.write_all(b"Hello, world!").unwrap();
+        let seals = libc::F_SEAL_SHRINK | libc::F_SEAL_WRITE;
+        unsafe { libc::fcntl(file.as_raw_fd(), libc::F_ADD_SEALS, seals) };
+
+        let mmap = MmapOptions::new()
+            .offset(7)
+            .map_if_safe(&file)
+            .unwrap()
+            .unwrap();
+        assert_eq!(&mmap[..], b"world!");
+
+        // Mapping beyond file size should return None
+        assert!(MmapOptions::new()
+            .offset(7)
+            .len(100)
+            .map_if_safe(&file)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    fn map_if_safe_regular_file() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("regular");
+
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(path)
+            .unwrap();
+        file.set_len(128).unwrap();
+
+        assert!(Mmap::map_if_safe(&file).unwrap().is_none());
+    }
+
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn map_if_safe_verity() {
+        #[repr(C)]
+        struct FsVerityEnableArg {
+            version: u32,
+            hash_algorithm: u32,
+            block_size: u32,
+            salt_size: u32,
+            salt_ptr: u64,
+            sig_size: u32,
+            _reserved1: u32,
+            sig_ptr: u64,
+            _reserved2: [u64; 11],
+        }
+
+        // _IOW('f', 133, fsverity_enable_arg) — MIPS uses different ioctl encoding
+        #[cfg(any(target_arch = "mips", target_arch = "mips64"))]
+        const FS_IOC_ENABLE_VERITY: libc::c_ulong = 0x80806685;
+        #[cfg(not(any(target_arch = "mips", target_arch = "mips64")))]
+        const FS_IOC_ENABLE_VERITY: libc::c_ulong = 0x40806685;
+
+        let tempdir = match std::env::var("MEMMAP2_TEST_VERITY_DIR") {
+            Ok(dir) => tempfile::TempDir::new_in(dir).unwrap(),
+            Err(_) => tempfile::tempdir().unwrap(),
+        };
+        let path = tempdir.path().join("verity_test");
+
+        File::create(&path)
+            .unwrap()
+            .write_all(b"Hello, verity!")
+            .unwrap();
+
+        let file = File::open(&path).unwrap();
+
+        let arg = FsVerityEnableArg {
+            version: 1,
+            hash_algorithm: 1, // FS_VERITY_HASH_ALG_SHA256
+            block_size: 4096,
+            salt_size: 0,
+            salt_ptr: 0,
+            sig_size: 0,
+            _reserved1: 0,
+            sig_ptr: 0,
+            _reserved2: [0; 11],
+        };
+
+        #[allow(clippy::cast_possible_wrap)]
+        let ret = unsafe { libc::ioctl(file.as_raw_fd(), FS_IOC_ENABLE_VERITY as _, &arg) };
+        if ret != 0 {
+            eprintln!("skipping: fs-verity not supported on this filesystem");
+            return;
+        }
+
+        let mmap = Mmap::map_if_safe(&file).unwrap().unwrap();
+        assert_eq!(&mmap[..], b"Hello, verity!");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,93 @@ where
     }
 }
 
+/// Error returned by [`MmapOptions::map_if_safe()`].
+///
+/// Allows you to distinguish between three failure modes:
+///
+/// * Safe mapping is not supported on this platform.
+/// * Trying to map an unsafe file descriptor.
+/// * The map attempt itself failed.
+///
+/// The error is convertible to [`std::io::Error`].
+pub struct MapIfSafeError {
+    inner: MapIfSafeErrorInner,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)] // Not all variants are constructed on all platforms.
+enum MapIfSafeErrorInner {
+    NotSupported,
+    NotSafe(std::io::Error),
+    MapFailed(std::io::Error),
+}
+
+impl MapIfSafeError {
+    #[allow(dead_code)] // Not all variants are constructed on all platforms.
+    fn new_not_supported() -> Self {
+        let inner = MapIfSafeErrorInner::NotSupported;
+        Self { inner }
+    }
+
+    #[allow(dead_code)] // Not all variants are constructed on all platforms.
+    fn new_not_safe(reason: std::io::Error) -> Self {
+        let inner = MapIfSafeErrorInner::NotSafe(reason);
+        Self { inner }
+    }
+
+    #[allow(dead_code)] // Not all variants are constructed on all platforms.
+    fn new_map_failed(reason: std::io::Error) -> Self {
+        let inner = MapIfSafeErrorInner::MapFailed(reason);
+        Self { inner }
+    }
+
+    /// Indicates that safe mapping is not supported at all on this platform.
+    pub fn not_supported(&self) -> bool {
+        matches!(self.inner, MapIfSafeErrorInner::NotSupported)
+    }
+
+    /// Indicates if the map was refused because mapping the file descriptor is not safe.
+    pub fn not_safe(&self) -> bool {
+        matches!(self.inner, MapIfSafeErrorInner::NotSafe(_))
+    }
+
+    /// Indicates if the file descriptor to be mapped was considered safe, but the mapping itself failed.
+    pub fn map_failed(&self) -> bool {
+        matches!(self.inner, MapIfSafeErrorInner::MapFailed(_))
+    }
+}
+
+impl std::error::Error for MapIfSafeError {}
+
+impl fmt::Display for MapIfSafeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[allow(clippy::match_same_arms)]
+        match &self.inner {
+            MapIfSafeErrorInner::NotSupported => {
+                fmt::Display::fmt(&Error::from(ErrorKind::Unsupported), f)
+            }
+            MapIfSafeErrorInner::NotSafe(e) => fmt::Display::fmt(e, f),
+            MapIfSafeErrorInner::MapFailed(e) => fmt::Display::fmt(e, f),
+        }
+    }
+}
+
+impl fmt::Debug for MapIfSafeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.inner, f)
+    }
+}
+
+impl From<MapIfSafeError> for std::io::Error {
+    fn from(value: MapIfSafeError) -> Self {
+        match value.inner {
+            MapIfSafeErrorInner::NotSupported => std::io::ErrorKind::Unsupported.into(),
+            MapIfSafeErrorInner::NotSafe(e) => e,
+            MapIfSafeErrorInner::MapFailed(e) => e,
+        }
+    }
+}
+
 /// A memory map builder, providing advanced options and flags for specifying memory map behavior.
 ///
 /// `MmapOptions` can be used to create an anonymous memory map using [`map_anon()`], or a
@@ -621,12 +708,12 @@ impl MmapOptions {
     /// - A file with fs-verity enabled (Linux and Android only).
     ///
     /// [`map()`]: MmapOptions::map()
-    pub fn map_if_safe<T: MmapAsRawDesc>(&self, file: T) -> std::io::Result<Option<Mmap>> {
+    pub fn map_if_safe<T: MmapAsRawDesc>(&self, file: T) -> Result<Mmap, MapIfSafeError> {
         let desc = file.as_raw_desc();
-        let len = self.get_len(&file)?;
-        if !MmapInner::check_safe_to_map(desc.0, self.offset, len)? {
-            return Ok(None);
-        }
+        let len = self
+            .get_len(&file)
+            .map_err(MapIfSafeError::new_map_failed)?;
+        MmapInner::check_safe_to_map(desc.0, self.offset, len)?;
         MmapInner::map(
             len,
             desc.0,
@@ -634,7 +721,8 @@ impl MmapOptions {
             self.populate,
             self.no_reserve_swap,
         )
-        .map(|inner| Some(Mmap { inner }))
+        .map_err(MapIfSafeError::new_map_failed)
+        .map(|inner| Mmap { inner })
     }
 
     /// Creates an anonymous memory map.
@@ -803,7 +891,7 @@ impl Mmap {
     ///
     /// This is equivalent to calling `MmapOptions::new().map_if_safe(file)`.
     /// See [`MmapOptions::map_if_safe()`] for details.
-    pub fn map_if_safe<T: MmapAsRawDesc>(file: T) -> std::io::Result<Option<Mmap>> {
+    pub fn map_if_safe<T: MmapAsRawDesc>(file: T) -> Result<Mmap, MapIfSafeError> {
         MmapOptions::new().map_if_safe(file)
     }
 
@@ -2377,16 +2465,16 @@ mod test {
 
         file.write_all(b"Hello, world!").unwrap();
 
-        // Should return None without seals
-        assert!(Mmap::map_if_safe(&file).unwrap().is_none());
+        // Should report not-safe without seals.
+        assert!(Mmap::map_if_safe(&file).unwrap_err().not_safe());
 
-        // Should return None with only F_SEAL_SHRINK
+        // Should report not-safe with only F_SEAL_SHRINK
         unsafe { libc::fcntl(file.as_raw_fd(), libc::F_ADD_SEALS, libc::F_SEAL_SHRINK) };
-        assert!(Mmap::map_if_safe(&file).unwrap().is_none());
+        assert!(Mmap::map_if_safe(&file).unwrap_err().not_safe());
 
         // Should succeed with both seals
         unsafe { libc::fcntl(file.as_raw_fd(), libc::F_ADD_SEALS, libc::F_SEAL_WRITE) };
-        let mmap = Mmap::map_if_safe(&file).unwrap().unwrap();
+        let mmap = Mmap::map_if_safe(&file).unwrap();
         assert_eq!(&mmap[..], b"Hello, world!");
     }
 
@@ -2412,20 +2500,16 @@ mod test {
         let seals = libc::F_SEAL_SHRINK | libc::F_SEAL_WRITE;
         unsafe { libc::fcntl(file.as_raw_fd(), libc::F_ADD_SEALS, seals) };
 
-        let mmap = MmapOptions::new()
-            .offset(7)
-            .map_if_safe(&file)
-            .unwrap()
-            .unwrap();
+        let mmap = MmapOptions::new().offset(7).map_if_safe(&file).unwrap();
         assert_eq!(&mmap[..], b"world!");
 
-        // Mapping beyond file size should return None
+        // Mapping beyond file size should report not-safe
         assert!(MmapOptions::new()
             .offset(7)
             .len(100)
             .map_if_safe(&file)
-            .unwrap()
-            .is_none());
+            .unwrap_err()
+            .not_safe());
     }
 
     #[test]
@@ -2443,7 +2527,7 @@ mod test {
             .unwrap();
         file.set_len(128).unwrap();
 
-        assert!(Mmap::map_if_safe(&file).unwrap().is_none());
+        assert!(Mmap::map_if_safe(&file).unwrap_err().not_safe());
     }
 
     #[test]
@@ -2500,7 +2584,7 @@ mod test {
             return;
         }
 
-        let mmap = Mmap::map_if_safe(&file).unwrap().unwrap();
+        let mmap = Mmap::map_if_safe(&file).unwrap();
         assert_eq!(&mmap[..], b"Hello, verity!");
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,7 +70,7 @@ pub use crate::advice::{Advice, UncheckedAdvice};
 use std::fmt;
 #[cfg(not(any(unix, windows)))]
 use std::fs::File;
-use std::io::{Error, ErrorKind, Result};
+use std::io::{Error, ErrorKind};
 use std::ops::{Deref, DerefMut};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -244,7 +244,7 @@ impl MmapOptions {
         self
     }
 
-    fn validate_len(len: u64) -> Result<usize> {
+    fn validate_len(len: u64) -> std::io::Result<usize> {
         // Rust's slice cannot be larger than isize::MAX.
         // See https://doc.rust-lang.org/std/slice/fn.from_raw_parts.html
         //
@@ -262,7 +262,7 @@ impl MmapOptions {
     }
 
     /// Returns the configured length, or the length of the provided file.
-    fn get_len<T: MmapAsRawDesc>(&self, file: &T) -> Result<usize> {
+    fn get_len<T: MmapAsRawDesc>(&self, file: &T) -> std::io::Result<usize> {
         let len = if let Some(len) = self.len {
             len as u64
         } else {
@@ -426,7 +426,7 @@ impl MmapOptions {
     /// # Ok(())
     /// # }
     /// ```
-    pub unsafe fn map<T: MmapAsRawDesc>(&self, file: T) -> Result<Mmap> {
+    pub unsafe fn map<T: MmapAsRawDesc>(&self, file: T) -> std::io::Result<Mmap> {
         let desc = file.as_raw_desc();
 
         MmapInner::map(
@@ -451,7 +451,7 @@ impl MmapOptions {
     /// variety of reasons, such as when the file is not open with read permissions.
     ///
     /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
-    pub unsafe fn map_exec<T: MmapAsRawDesc>(&self, file: T) -> Result<Mmap> {
+    pub unsafe fn map_exec<T: MmapAsRawDesc>(&self, file: T) -> std::io::Result<Mmap> {
         let desc = file.as_raw_desc();
 
         MmapInner::map_exec(
@@ -500,7 +500,7 @@ impl MmapOptions {
     /// # Ok(())
     /// # }
     /// ```
-    pub unsafe fn map_mut<T: MmapAsRawDesc>(&self, file: T) -> Result<MmapMut> {
+    pub unsafe fn map_mut<T: MmapAsRawDesc>(&self, file: T) -> std::io::Result<MmapMut> {
         let desc = file.as_raw_desc();
 
         MmapInner::map_mut(
@@ -543,7 +543,7 @@ impl MmapOptions {
     /// # Ok(())
     /// # }
     /// ```
-    pub unsafe fn map_copy<T: MmapAsRawDesc>(&self, file: T) -> Result<MmapMut> {
+    pub unsafe fn map_copy<T: MmapAsRawDesc>(&self, file: T) -> std::io::Result<MmapMut> {
         let desc = file.as_raw_desc();
 
         MmapInner::map_copy(
@@ -590,7 +590,7 @@ impl MmapOptions {
     /// # Ok(())
     /// # }
     /// ```
-    pub unsafe fn map_copy_read_only<T: MmapAsRawDesc>(&self, file: T) -> Result<Mmap> {
+    pub unsafe fn map_copy_read_only<T: MmapAsRawDesc>(&self, file: T) -> std::io::Result<Mmap> {
         let desc = file.as_raw_desc();
 
         MmapInner::map_copy_read_only(
@@ -621,7 +621,7 @@ impl MmapOptions {
     /// - A file with fs-verity enabled (Linux and Android only).
     ///
     /// [`map()`]: MmapOptions::map()
-    pub fn map_if_safe<T: MmapAsRawDesc>(&self, file: T) -> Result<Option<Mmap>> {
+    pub fn map_if_safe<T: MmapAsRawDesc>(&self, file: T) -> std::io::Result<Option<Mmap>> {
         let desc = file.as_raw_desc();
         let len = self.get_len(&file)?;
         if !MmapInner::check_safe_to_map(desc.0, self.offset, len)? {
@@ -649,7 +649,7 @@ impl MmapOptions {
     /// when `len > isize::MAX`.
     ///
     /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
-    pub fn map_anon(&self) -> Result<MmapMut> {
+    pub fn map_anon(&self) -> std::io::Result<MmapMut> {
         let len = self.len.unwrap_or(0);
 
         // See get_len() for details.
@@ -673,7 +673,7 @@ impl MmapOptions {
     /// variety of reasons, such as when the file is not open with read and write permissions.
     ///
     /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
-    pub fn map_raw<T: MmapAsRawDesc>(&self, file: T) -> Result<MmapRaw> {
+    pub fn map_raw<T: MmapAsRawDesc>(&self, file: T) -> std::io::Result<MmapRaw> {
         let desc = file.as_raw_desc();
 
         MmapInner::map_mut(
@@ -696,7 +696,7 @@ impl MmapOptions {
     /// This method returns an error when the underlying system call fails.
     ///
     /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
-    pub fn map_raw_read_only<T: MmapAsRawDesc>(&self, file: T) -> Result<MmapRaw> {
+    pub fn map_raw_read_only<T: MmapAsRawDesc>(&self, file: T) -> std::io::Result<MmapRaw> {
         let desc = file.as_raw_desc();
 
         MmapInner::map(
@@ -793,7 +793,7 @@ impl Mmap {
     /// # Ok(())
     /// # }
     /// ```
-    pub unsafe fn map<T: MmapAsRawDesc>(file: T) -> Result<Mmap> {
+    pub unsafe fn map<T: MmapAsRawDesc>(file: T) -> std::io::Result<Mmap> {
         // SAFETY: safety requirements forwarded to caller.
         unsafe { MmapOptions::new().map(file) }
     }
@@ -803,7 +803,7 @@ impl Mmap {
     ///
     /// This is equivalent to calling `MmapOptions::new().map_if_safe(file)`.
     /// See [`MmapOptions::map_if_safe()`] for details.
-    pub fn map_if_safe<T: MmapAsRawDesc>(file: T) -> Result<Option<Mmap>> {
+    pub fn map_if_safe<T: MmapAsRawDesc>(file: T) -> std::io::Result<Option<Mmap>> {
         MmapOptions::new().map_if_safe(file)
     }
 
@@ -842,7 +842,7 @@ impl Mmap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn make_mut(mut self) -> Result<MmapMut> {
+    pub fn make_mut(mut self) -> std::io::Result<MmapMut> {
         self.inner.make_mut()?;
         Ok(MmapMut { inner: self.inner })
     }
@@ -853,7 +853,7 @@ impl Mmap {
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
-    pub fn advise(&self, advice: Advice) -> Result<()> {
+    pub fn advise(&self, advice: Advice) -> std::io::Result<()> {
         // SAFETY: The `Advice` enum only allows safe advice values.
         unsafe {
             self.inner
@@ -872,7 +872,7 @@ impl Mmap {
     /// Care must be taken not to break the soundness rules of the Rust compiler.
     /// Refer to the operating system documentation to see what each of the [`UncheckedAdvice`] variant does.
     #[cfg(unix)]
-    pub unsafe fn unchecked_advise(&self, advice: UncheckedAdvice) -> Result<()> {
+    pub unsafe fn unchecked_advise(&self, advice: UncheckedAdvice) -> std::io::Result<()> {
         // SAFETY: safety requirements forwarded to caller.
         unsafe {
             self.inner
@@ -888,7 +888,7 @@ impl Mmap {
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
-    pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
+    pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> std::io::Result<()> {
         // SAFETY: The `Advice` enum only allows safe advice values.
         unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
@@ -911,7 +911,7 @@ impl Mmap {
         advice: UncheckedAdvice,
         offset: usize,
         len: usize,
-    ) -> Result<()> {
+    ) -> std::io::Result<()> {
         // SAFETY: safety requirements forwarded to caller.
         unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
@@ -920,7 +920,7 @@ impl Mmap {
     ///
     /// See [mlock()](https://man7.org/linux/man-pages/man2/mlock.2.html) map page.
     #[cfg(unix)]
-    pub fn lock(&self) -> Result<()> {
+    pub fn lock(&self) -> std::io::Result<()> {
         self.inner.lock()
     }
 
@@ -928,7 +928,7 @@ impl Mmap {
     ///
     /// See [munlock()](https://man7.org/linux/man-pages/man2/munlock.2.html) map page.
     #[cfg(unix)]
-    pub fn unlock(&self) -> Result<()> {
+    pub fn unlock(&self) -> std::io::Result<()> {
         self.inner.unlock()
     }
 
@@ -950,7 +950,7 @@ impl Mmap {
     ///
     /// [`mremap(2)`]: https://man7.org/linux/man-pages/man2/mremap.2.html
     #[cfg(target_os = "linux")]
-    pub unsafe fn remap(&mut self, new_len: usize, options: RemapOptions) -> Result<()> {
+    pub unsafe fn remap(&mut self, new_len: usize, options: RemapOptions) -> std::io::Result<()> {
         self.inner.remap(new_len, options)
     }
 }
@@ -1005,7 +1005,7 @@ impl MmapRaw {
     /// variety of reasons, such as when the file is not open with read and write permissions.
     ///
     /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
-    pub fn map_raw<T: MmapAsRawDesc>(file: T) -> Result<MmapRaw> {
+    pub fn map_raw<T: MmapAsRawDesc>(file: T) -> std::io::Result<MmapRaw> {
         MmapOptions::new().map_raw(file)
     }
 
@@ -1070,7 +1070,7 @@ impl MmapRaw {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn flush(&self) -> Result<()> {
+    pub fn flush(&self) -> std::io::Result<()> {
         let len = self.len();
         self.inner.flush(0, len)
     }
@@ -1080,7 +1080,7 @@ impl MmapRaw {
     /// This method initiates flushing modified pages to durable storage, but it will not wait for
     /// the operation to complete before returning. The file's metadata (including last
     /// modification timestamp) may not be updated.
-    pub fn flush_async(&self) -> Result<()> {
+    pub fn flush_async(&self) -> std::io::Result<()> {
         let len = self.len();
         self.inner.flush_async(0, len)
     }
@@ -1094,7 +1094,7 @@ impl MmapRaw {
     /// last modification timestamp) may not be updated. It is not guaranteed the only the changes
     /// in the specified range are flushed; other outstanding changes to the memory map may be
     /// flushed as well.
-    pub fn flush_range(&self, offset: usize, len: usize) -> Result<()> {
+    pub fn flush_range(&self, offset: usize, len: usize) -> std::io::Result<()> {
         self.inner.flush(offset, len)
     }
 
@@ -1107,7 +1107,7 @@ impl MmapRaw {
     /// modification timestamp) may not be updated. It is not guaranteed that the only changes
     /// flushed are those in the specified range; other outstanding changes to the memory map may
     /// be flushed as well.
-    pub fn flush_async_range(&self, offset: usize, len: usize) -> Result<()> {
+    pub fn flush_async_range(&self, offset: usize, len: usize) -> std::io::Result<()> {
         self.inner.flush_async(offset, len)
     }
 
@@ -1117,7 +1117,7 @@ impl MmapRaw {
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
-    pub fn advise(&self, advice: Advice) -> Result<()> {
+    pub fn advise(&self, advice: Advice) -> std::io::Result<()> {
         // SAFETY: The `Advice` enum only allows safe advice values.
         unsafe {
             self.inner
@@ -1136,7 +1136,7 @@ impl MmapRaw {
     /// Care must be taken not to break the soundness rules of the Rust compiler.
     /// Refer to the operating system documentation to see what each of the [`UncheckedAdvice`] variant does.
     #[cfg(unix)]
-    pub unsafe fn unchecked_advise(&self, advice: UncheckedAdvice) -> Result<()> {
+    pub unsafe fn unchecked_advise(&self, advice: UncheckedAdvice) -> std::io::Result<()> {
         // SAFETY: safety requirements forwarded to caller.
         unsafe {
             self.inner
@@ -1152,7 +1152,7 @@ impl MmapRaw {
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
-    pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
+    pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> std::io::Result<()> {
         // SAFETY: The `Advice` enum only allows safe advice values.
         unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
@@ -1175,7 +1175,7 @@ impl MmapRaw {
         advice: UncheckedAdvice,
         offset: usize,
         len: usize,
-    ) -> Result<()> {
+    ) -> std::io::Result<()> {
         // SAFETY: safety requirements forwarded to caller.
         unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
@@ -1184,7 +1184,7 @@ impl MmapRaw {
     ///
     /// See [mlock()](https://man7.org/linux/man-pages/man2/mlock.2.html) map page.
     #[cfg(unix)]
-    pub fn lock(&self) -> Result<()> {
+    pub fn lock(&self) -> std::io::Result<()> {
         self.inner.lock()
     }
 
@@ -1192,7 +1192,7 @@ impl MmapRaw {
     ///
     /// See [munlock()](https://man7.org/linux/man-pages/man2/munlock.2.html) map page.
     #[cfg(unix)]
-    pub fn unlock(&self) -> Result<()> {
+    pub fn unlock(&self) -> std::io::Result<()> {
         self.inner.unlock()
     }
 
@@ -1214,7 +1214,7 @@ impl MmapRaw {
     ///
     /// [`mremap(2)`]: https://man7.org/linux/man-pages/man2/mremap.2.html
     #[cfg(target_os = "linux")]
-    pub unsafe fn remap(&mut self, new_len: usize, options: RemapOptions) -> Result<()> {
+    pub unsafe fn remap(&mut self, new_len: usize, options: RemapOptions) -> std::io::Result<()> {
         self.inner.remap(new_len, options)
     }
 }
@@ -1313,7 +1313,7 @@ impl MmapMut {
     /// # Ok(())
     /// # }
     /// ```
-    pub unsafe fn map_mut<T: MmapAsRawDesc>(file: T) -> Result<MmapMut> {
+    pub unsafe fn map_mut<T: MmapAsRawDesc>(file: T) -> std::io::Result<MmapMut> {
         // SAFETY: safety requirements forwarded to caller.
         unsafe { MmapOptions::new().map_mut(file) }
     }
@@ -1328,7 +1328,7 @@ impl MmapMut {
     /// when `len > isize::MAX`.
     ///
     /// Returns [`ErrorKind::Unsupported`] on unsupported platforms.
-    pub fn map_anon(length: usize) -> Result<MmapMut> {
+    pub fn map_anon(length: usize) -> std::io::Result<MmapMut> {
         MmapOptions::new().len(length).map_anon()
     }
 
@@ -1361,7 +1361,7 @@ impl MmapMut {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn flush(&self) -> Result<()> {
+    pub fn flush(&self) -> std::io::Result<()> {
         let len = self.len();
         self.inner.flush(0, len)
     }
@@ -1371,7 +1371,7 @@ impl MmapMut {
     /// This method initiates flushing modified pages to durable storage, but it will not wait for
     /// the operation to complete before returning. The file's metadata (including last
     /// modification timestamp) may not be updated.
-    pub fn flush_async(&self) -> Result<()> {
+    pub fn flush_async(&self) -> std::io::Result<()> {
         let len = self.len();
         self.inner.flush_async(0, len)
     }
@@ -1385,7 +1385,7 @@ impl MmapMut {
     /// last modification timestamp) may not be updated. It is not guaranteed the only the changes
     /// in the specified range are flushed; other outstanding changes to the memory map may be
     /// flushed as well.
-    pub fn flush_range(&self, offset: usize, len: usize) -> Result<()> {
+    pub fn flush_range(&self, offset: usize, len: usize) -> std::io::Result<()> {
         self.inner.flush(offset, len)
     }
 
@@ -1398,7 +1398,7 @@ impl MmapMut {
     /// modification timestamp) may not be updated. It is not guaranteed that the only changes
     /// flushed are those in the specified range; other outstanding changes to the memory map may
     /// be flushed as well.
-    pub fn flush_async_range(&self, offset: usize, len: usize) -> Result<()> {
+    pub fn flush_async_range(&self, offset: usize, len: usize) -> std::io::Result<()> {
         self.inner.flush_async(offset, len)
     }
 
@@ -1428,7 +1428,7 @@ impl MmapMut {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn make_read_only(mut self) -> Result<Mmap> {
+    pub fn make_read_only(mut self) -> std::io::Result<Mmap> {
         self.inner.make_read_only()?;
         Ok(Mmap { inner: self.inner })
     }
@@ -1447,7 +1447,7 @@ impl MmapMut {
     ///
     /// This method returns an error when the underlying system call fails, which can happen for a
     /// variety of reasons, such as when the file has not been opened with execute permissions.
-    pub fn make_exec(mut self) -> Result<Mmap> {
+    pub fn make_exec(mut self) -> std::io::Result<Mmap> {
         self.inner.make_exec()?;
         Ok(Mmap { inner: self.inner })
     }
@@ -1458,7 +1458,7 @@ impl MmapMut {
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
-    pub fn advise(&self, advice: Advice) -> Result<()> {
+    pub fn advise(&self, advice: Advice) -> std::io::Result<()> {
         // SAFETY: The `Advice` enum only allows safe advice values.
         unsafe {
             self.inner
@@ -1472,7 +1472,7 @@ impl MmapMut {
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
-    pub unsafe fn unchecked_advise(&self, advice: UncheckedAdvice) -> Result<()> {
+    pub unsafe fn unchecked_advise(&self, advice: UncheckedAdvice) -> std::io::Result<()> {
         // SAFETY: Safety requirements pushed to caller.
         unsafe {
             self.inner
@@ -1488,7 +1488,7 @@ impl MmapMut {
     ///
     /// See [madvise()](https://man7.org/linux/man-pages/man2/madvise.2.html) map page.
     #[cfg(unix)]
-    pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> Result<()> {
+    pub fn advise_range(&self, advice: Advice, offset: usize, len: usize) -> std::io::Result<()> {
         // SAFETY: The `Advice` enum only allows safe advice values.
         unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
@@ -1506,7 +1506,7 @@ impl MmapMut {
         advice: UncheckedAdvice,
         offset: usize,
         len: usize,
-    ) -> Result<()> {
+    ) -> std::io::Result<()> {
         // SAFETY: Safety requirements pushed to caller.
         unsafe { self.inner.advise(advice as libc::c_int, offset, len) }
     }
@@ -1515,7 +1515,7 @@ impl MmapMut {
     ///
     /// See [mlock()](https://man7.org/linux/man-pages/man2/mlock.2.html) map page.
     #[cfg(unix)]
-    pub fn lock(&self) -> Result<()> {
+    pub fn lock(&self) -> std::io::Result<()> {
         self.inner.lock()
     }
 
@@ -1523,7 +1523,7 @@ impl MmapMut {
     ///
     /// See [munlock()](https://man7.org/linux/man-pages/man2/munlock.2.html) map page.
     #[cfg(unix)]
-    pub fn unlock(&self) -> Result<()> {
+    pub fn unlock(&self) -> std::io::Result<()> {
         self.inner.unlock()
     }
 
@@ -1545,7 +1545,7 @@ impl MmapMut {
     ///
     /// [`mremap(2)`]: https://man7.org/linux/man-pages/man2/mremap.2.html
     #[cfg(target_os = "linux")]
-    pub unsafe fn remap(&mut self, new_len: usize, options: RemapOptions) -> Result<()> {
+    pub unsafe fn remap(&mut self, new_len: usize, options: RemapOptions) -> std::io::Result<()> {
         self.inner.remap(new_len, options)
     }
 }

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -77,6 +77,11 @@ impl MmapInner {
     pub fn len(&self) -> usize {
         match self.never {}
     }
+
+    #[allow(clippy::unnecessary_wraps)]
+    pub fn check_safe_to_map(_file: &File, _offset: u64, _len: usize) -> io::Result<bool> {
+        Ok(false)
+    }
 }
 
 pub fn file_len(file: &File) -> io::Result<u64> {

--- a/src/stub.rs
+++ b/src/stub.rs
@@ -79,8 +79,12 @@ impl MmapInner {
     }
 
     #[allow(clippy::unnecessary_wraps)]
-    pub fn check_safe_to_map(_file: &File, _offset: u64, _len: usize) -> io::Result<bool> {
-        Ok(false)
+    pub fn check_safe_to_map(
+        _file: &File,
+        _offset: u64,
+        _len: usize,
+    ) -> io::Result<(), crate::MapIfSafeError> {
+        Err(crate::MapIfSafeError::new_not_supported())
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -509,6 +509,55 @@ impl MmapInner {
             }
         }
     }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
+    #[allow(clippy::unnecessary_wraps)]
+    pub fn check_safe_to_map(_fd: RawFd, _offset: u64, _len: usize) -> io::Result<bool> {
+        Ok(false)
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn has_fs_verity(fd: RawFd) -> bool {
+        #[repr(C)]
+        struct FsVerityDigest {
+            digest_algorithm: u16,
+            digest_size: u16,
+        }
+        const FS_IOC_MEASURE_VERITY: libc::c_ulong = 0xC004_6686;
+
+        let mut digest = std::mem::MaybeUninit::<FsVerityDigest>::zeroed();
+        #[allow(clippy::cast_possible_wrap)]
+        let ret = unsafe { libc::ioctl(fd, FS_IOC_MEASURE_VERITY as _, digest.as_mut_ptr()) };
+        ret == 0 || io::Error::last_os_error().raw_os_error() == Some(libc::EOVERFLOW)
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    fn has_fs_verity(_fd: RawFd) -> bool {
+        false
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    pub fn check_safe_to_map(fd: RawFd, offset: u64, len: usize) -> io::Result<bool> {
+        let seals = unsafe { libc::fcntl(fd, libc::F_GET_SEALS) };
+        if seals >= 0 {
+            let required = libc::F_SEAL_SHRINK | libc::F_SEAL_WRITE;
+            if seals & required != required {
+                return Ok(false);
+            }
+        } else if !Self::has_fs_verity(fd) {
+            return Ok(false);
+        }
+
+        let file_size = file_len(fd)?;
+        let end = offset.checked_add(len as u64).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidInput, "mapping region overflows u64")
+        })?;
+        if end > file_size {
+            return Ok(false);
+        }
+
+        Ok(true)
+    }
 }
 
 impl Drop for MmapInner {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -513,10 +513,107 @@ impl MmapInner {
     #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
     #[allow(clippy::unnecessary_wraps)]
     pub fn check_safe_to_map(_fd: RawFd, _offset: u64, _len: usize) -> io::Result<bool> {
-        Ok(false)
+        Err(crate::MapIfSafeError::new_not_supported())
+    }
+
+    /// Check if a requisted region of a file is safe to map.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    pub fn check_safe_to_map(
+        fd: RawFd,
+        offset: u64,
+        len: usize,
+    ) -> Result<(), crate::MapIfSafeError> {
+        // First check if the FD itself is safe.
+        Self::check_fd_safe_to_map(fd)?;
+
+        // Now check if the mapping request including offset and length is safe.
+        let file_size = file_len(fd).map_err(|e| {
+            crate::MapIfSafeError::new_not_safe(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("fd is not safe to map: failed to determine file size: {e}"),
+            ))
+        })?;
+
+        let end = offset.checked_add(len as u64).ok_or_else(|| {
+            crate::MapIfSafeError::new_map_failed(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "mapping region overflows u64",
+            ))
+        })?;
+        if end > file_size {
+            return Err(crate::MapIfSafeError::new_not_safe(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("map request is not safe: offset + length ({end}) exceeds the size of the file ({file_size})"),
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Check if a file descriptor is safe to map.
+    ///
+    /// This only checks the file, not the whole map request.
+    /// A request to map more than the file contents must still be rejected.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    fn check_fd_safe_to_map(fd: RawFd) -> Result<(), crate::MapIfSafeError> {
+        // Check for properly sealed memfd on Linux, Android and FreeBSD.
+        if let Some(seals) = Self::get_memfd_seals(fd) {
+            return Self::check_memfd_seals(seals);
+        }
+
+        // On FreeBSD we have not more checks.
+        #[cfg(target_os = "freebsd")]
+        return Err(crate::MapIfSafeError::new_not_safe(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "fd is not safe to map: it is not a memfd",
+        )));
+
+        // Also check for fs-verity on Linux and Android.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if Self::has_fs_verity(fd) {
+            Ok(())
+        } else {
+            Err(crate::MapIfSafeError::new_not_safe(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "fd is not safe to map: it is not a memfd and it has no fs-verity",
+            )))
+        }
+    }
+
+    /// Get the seals of a memfd.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    fn get_memfd_seals(fd: RawFd) -> Option<libc::c_int> {
+        // SAFETY: F_GET_SEALS has no side effects, and just returns an error on invalid FDs.
+        let seals = unsafe { libc::fcntl(fd, libc::F_GET_SEALS) };
+        if seals >= 0 {
+            Some(seals)
+        } else {
+            None
+        }
+    }
+
+    /// Check if the seals of a memfd to see if the FD is immutable (and safe to map).
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    fn check_memfd_seals(seals: libc::c_int) -> Result<(), crate::MapIfSafeError> {
+        let required = libc::F_SEAL_SHRINK | libc::F_SEAL_WRITE;
+        let overlap = seals & required;
+        if overlap == required {
+            Ok(())
+        } else {
+            let error = match overlap {
+                libc::F_SEAL_SHRINK => "fd is not safe to map: missing seals F_SEAL_WRITE",
+                libc::F_SEAL_WRITE => "fd is not safe to map: missing seals F_SEAL_SHRINK",
+                _ => "fd is not safe to map: missing seals F_SEAL_SHRINK and F_SEAL_WRITE",
+            };
+            Err(crate::MapIfSafeError::new_not_safe(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                error,
+            )))
+        }
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]
+    /// Check if a file has vs-verity enabled.
     fn has_fs_verity(fd: RawFd) -> bool {
         #[repr(C)]
         struct FsVerityDigest {
@@ -529,34 +626,6 @@ impl MmapInner {
         #[allow(clippy::cast_possible_wrap)]
         let ret = unsafe { libc::ioctl(fd, FS_IOC_MEASURE_VERITY as _, digest.as_mut_ptr()) };
         ret == 0 || io::Error::last_os_error().raw_os_error() == Some(libc::EOVERFLOW)
-    }
-
-    #[cfg(not(any(target_os = "linux", target_os = "android")))]
-    fn has_fs_verity(_fd: RawFd) -> bool {
-        false
-    }
-
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
-    pub fn check_safe_to_map(fd: RawFd, offset: u64, len: usize) -> io::Result<bool> {
-        let seals = unsafe { libc::fcntl(fd, libc::F_GET_SEALS) };
-        if seals >= 0 {
-            let required = libc::F_SEAL_SHRINK | libc::F_SEAL_WRITE;
-            if seals & required != required {
-                return Ok(false);
-            }
-        } else if !Self::has_fs_verity(fd) {
-            return Ok(false);
-        }
-
-        let file_size = file_len(fd)?;
-        let end = offset.checked_add(len as u64).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidInput, "mapping region overflows u64")
-        })?;
-        if end > file_size {
-            return Ok(false);
-        }
-
-        Ok(true)
     }
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -489,6 +489,11 @@ impl MmapInner {
     pub fn len(&self) -> usize {
         self.len
     }
+
+    #[allow(clippy::unnecessary_wraps)]
+    pub fn check_safe_to_map(_handle: RawHandle, _offset: u64, _len: usize) -> io::Result<bool> {
+        Ok(false)
+    }
 }
 
 impl Drop for MmapInner {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -491,8 +491,12 @@ impl MmapInner {
     }
 
     #[allow(clippy::unnecessary_wraps)]
-    pub fn check_safe_to_map(_handle: RawHandle, _offset: u64, _len: usize) -> io::Result<bool> {
-        Ok(false)
+    pub fn check_safe_to_map(
+        _handle: RawHandle,
+        _offset: u64,
+        _len: usize,
+    ) -> Result<(), crate::MapIfSafeError> {
+        Err(crate::MapIfSafeError::new_not_supported())
     }
 }
 


### PR DESCRIPTION
This allows mapping of immutable files with no unsafe. Files are considered immutable if they can't shrink or change contents. Such files are safe to map, at least if the mapped region is within the size of the immutable file.

We currently support two kinds of immutable files:
 * Memfd:s with shrink and write seals
 * Regular files that have fs-verity enabled

For now this is only supported on Linux, but the API is available everywhere, because in theory it other types of immutable files could be added.